### PR TITLE
Update bru-language-tag-reference.md

### DIFF
--- a/docs/bru-language-tag-reference.md
+++ b/docs/bru-language-tag-reference.md
@@ -25,7 +25,7 @@ get {
 
 Make a post http call
 ```
-get {
+post {
   url: https://api.github.com/users/usebruno
 }
 ```


### PR DESCRIPTION
Corrected the method name mentioned for the post API section. Changed it from 'get' to 'post'.