### PR TITLE
Updated terminology

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,7 +26,7 @@ function sidebar() {
       text: 'Introduction',
       collapsible: true,
       items: [
-        { text: 'Mainfesto', link: '/manifesto' },
+        { text: 'Manifesto', link: '/manifesto' },
         { text: 'Support', link: '/support' }
       ]
     },
@@ -50,7 +50,7 @@ function sidebar() {
         { text: 'Response Query', link: '/scripting/response-query' },
         { text: 'Inbuilt Libraries', link: '/scripting/inbuilt-libraries' },
         { text: 'External Libraries', link: '/scripting/external-libraries' },
-        { text: 'Javascript Reference', link: '/scripting/javascript-reference' },
+        { text: 'JavaScript Reference', link: '/scripting/javascript-reference' },
       ]
     },
     {
@@ -59,7 +59,7 @@ function sidebar() {
       items: [
         { text: 'Getting Started', link: '/testing/introduction' },
         { text: 'Assertions', link: '/testing/assertions' },
-        { text: 'Javascript Reference', link: '/testing/javascript-reference' },
+        { text: 'JavaScript Reference', link: '/testing/javascript-reference' },
       ]
     }
   ];

--- a/docs/bru-lang-extensions.md
+++ b/docs/bru-lang-extensions.md
@@ -1,6 +1,5 @@
 # Syntax Highlighting Support
 
-Bruno has editor extension released for VS Code. <br />
-You can download it from [here](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno)
+Bruno has editor extension released for VS Code.  You can download it from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno).
 
 Extensions for IntelliJ and the JetBrains family of IDEs are under development.

--- a/docs/bru-lang-overview.md
+++ b/docs/bru-lang-overview.md
@@ -6,8 +6,8 @@ The api requests in your collections are stored as plain text files using this l
 
 This allows you to save your API collections in a folder within your code repository, and use your preferred version control system to manage and share them with your team. Collaboration on your API collections can be done through pull requests, as the human-readable file format makes it easy for developers to understand the changes made to the API collection.
 
-Below is a sample of a Bru file for a get request with some query params
+Below is a sample of a Bru file for a `GET` request with some query params
 
 ![bru lang sample](public/images/github-collection.png)
 
-You can checkout the sample repository which contains github rest api collection [here](https://github.com/usebruno/github-rest-api-collection)
+You can checkout the sample repository which contains GitHub rest API collection [here](https://github.com/usebruno/github-rest-api-collection)

--- a/docs/bru-language-samples.md
+++ b/docs/bru-language-samples.md
@@ -1,6 +1,6 @@
 # Samples
 
-Here are a few sample bru files.
+Here are a few sample Bru files.
 
 ## GET
 ```bash
@@ -82,5 +82,3 @@ tests {
   });
 }
 ```
-
-

--- a/docs/bru-language-tag-reference.md
+++ b/docs/bru-language-tag-reference.md
@@ -15,7 +15,7 @@ The `type` can be either `http` or `graphql`
 
 ## get
 
-Make a get http call
+Make a `GET` http call
 ```
 get {
   url: https://api.github.com/users/usebruno
@@ -23,7 +23,7 @@ get {
 ```
 ## post
 
-Make a post http call
+Make a `POST` http call
 ```
 post {
   url: https://api.github.com/users/usebruno
@@ -31,7 +31,7 @@ post {
 ```
 ## put
 
-Make a put http call
+Make a `PUT` http call
 ```
 put {
   url: https://api.github.com/users/usebruno
@@ -39,7 +39,7 @@ put {
 ```
 ## delete
 
-Make a delete http call
+Make a `DELETE` http call
 ```
 delete {
   url: https://api.github.com/users/usebruno
@@ -47,7 +47,7 @@ delete {
 ```
 ## options
 
-Make a get options call
+Make a get `OPTIONS` call
 ```
 options {
   url: https://api.github.com/users/usebruno
@@ -55,7 +55,7 @@ options {
 ```
 ## trace
 
-Make a trace http call
+Make a `TRACE` http call
 ```
 trace {
   url: https://api.github.com/users/usebruno
@@ -63,7 +63,7 @@ trace {
 ```
 ## connect
 
-Make a connect http call
+Make a `CONNECT` http call
 ```
 connect {
   url: https://api.github.com/users/usebruno
@@ -71,7 +71,7 @@ connect {
 ```
 ## head
 
-Make a head http call
+Make a `HEAD` http call
 ```
 head {
   url: https://api.github.com/users/usebruno

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 # Bruno
 
-An Opensource IDE for exploring and testing Api's
+An Opensource IDE for exploring and testing APIs
 
 Bruno is a new and innovative API client, aimed at revolutionizing the status quo represented by Postman and similar tools out there.
 
 Bruno stores your collections directly in a folder on your filesystem. We use a plain text markup language, Bru, to save information about API requests.
 
-You can use git or any version control of your choice to collaborate over your api collections.
+You can use git or any version control of your choice to collaborate over your API collections.
 
 ![Image](https://www.usebruno.com/images/landing-2.png)

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -4,10 +4,10 @@ It's time for a revolution in API client technology. The status quo, represented
 
 We are an opensource project, rising up against the monopoly of bloated and closed systems. We believe that API collections should be co-located within your source code repository, serving as a living set of examples on how to use the API.
 
-But we realized that the current tools on the market export collections as giant JSON files (a.k.a ugly blobs), difficult to version control and diff. So we created the *Bru Markup language*, saving information about your API requests using plain text files.
+But we realized that the current tools on the market export collections as giant JSON files (a.k.a. ugly blobs), difficult to version control and diff. So we created the *Bru Markup language*, saving information about your API requests using plain text files.
 
 With Bruno, collections become first-class citizens, co-located with related information and easily version controlled. We say goodbye to bloated workspaces and global environments, and embrace the benefits of co-location.
 
-We dream of a world where developers can clone a code repo, get it up and running, use bruno to browse the examples on how to use the api and start playing with it. No more horror stories of *"Tim had the collections for the payment-api service, but he left the company last month."*
+We dream of a world where developers can clone a code repo, get it up and running, use Bruno to browse the examples on how to use the API and start playing with it. No more horror stories of *"Tim had the collections for the payment-api service, but he left the company last month."*
 
 Join us in our mission to create a better API client for developers. Say goodbye to bloatware and hello to simplicity, efficiency and freedom. Try Bruno today and experience the difference for yourself.

--- a/docs/scripting/inbuilt-libraries.md
+++ b/docs/scripting/inbuilt-libraries.md
@@ -8,7 +8,7 @@ Below are the list of inbuilt libraries that you can use you in your scripts. Yo
 - [lodash](https://lodash.com) -  A modern JavaScript utility library delivering modularity, performance & extras.
 - [uuid](https://www.npmjs.com/package/uuid) -  For the creation of RFC4122 UUIDs
 - [nanoid](https://www.npmjs.com/package/nanoid) - A tiny, secure, URL-friendly, unique string ID generator for JavaScript.
-- [crypto-js](https://www.npmjs.com/package/crypto-js) - JavaScript library of crypto standards. for JavaScript.
+- [crypto-js](https://www.npmjs.com/package/crypto-js) - JavaScript library of crypto standards.
 
 
 **Example:**

--- a/docs/scripting/introduction.md
+++ b/docs/scripting/introduction.md
@@ -1,5 +1,5 @@
 # Scripting
 
-Bruno offers scripting support to help you to add additional functionality to the tool such as data generation, validation and integration with other tools and systems, including sending intermediate requests, parsing response data, updating environment variables etc..
+Bruno offers scripting support to help you to add additional functionality to the tool such as data generation, validation and integration with other tools and systems, including sending intermediate requests, parsing response data, updating environment variables, etc.
 
 ![bru lang sample](../public/images/scripting.png)

--- a/docs/scripting/javascript-reference.md
+++ b/docs/scripting/javascript-reference.md
@@ -1,11 +1,11 @@
-# Javascript API Reference
+# JavaScript API Reference
 
 Here is the complete set of API reference for the scripting feature in Bruno.
 
 ## Request
 This `req` variable is available inside your scripting and testing context.
 
-Below is the api documentation for the methods available on `req` 
+Below is the API documentation for the methods available on `req` 
 ### `getUrl`
 Get the current request url
 

--- a/docs/scripting/vars.md
+++ b/docs/scripting/vars.md
@@ -2,9 +2,9 @@
 
 Vars allow you to set variables before request, and after your receive the response.
 
-In the *Pre Request Variables* section, you can write any Strings, Numbers or any valid javascript literal.
+In the *Pre Request Variables* section, you can write any Strings, Numbers or any valid JavaScript literal.
 
-In the *Post Response Variables* section, you can write any valid javascript expression. The res object is available, allowing you to declaratively parse the [response](./javascript-reference.html#response) and set variables, instead of writing scripts to do the same.
+In the *Post Response Variables* section, you can write any valid JavaScript expression. The res object is available, allowing you to declaratively parse the [response](./javascript-reference.html#response) and set variables, instead of writing scripts to do the same.
 
 For parsing the response, you can checkout the [response query](./response-query) that allows you to easily query your response.
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,5 +1,5 @@
 # Support
 
-Please use [Github Issues](https://www.github.com/usebruno/bruno/issues) to provide feedback and raise defects or feature requests.<br />
+Please use [GitHub Issues](https://www.github.com/usebruno/bruno/issues) to provide feedback and raise defects or feature requests.<br />
 
 We are also on [Twitter](https://twitter.com/use_bruno), [Linkedin](https://www.linkedin.com/company/usebruno) and [Discord](https://discord.com/invite/KgcZUncpjq)

--- a/docs/testing/introduction.md
+++ b/docs/testing/introduction.md
@@ -1,6 +1,6 @@
 # Testing
 
-Bruno supports writing automation test scripts in javaScript for your api requests to assert its behaviour.
+Bruno supports writing automation test scripts in JavaScript for your API requests to assert its behaviour.
 
 Some of the benefits include
 - Increased efficiency: The tests can be run repeatedly, reducing the time and effort required for manual testing.

--- a/docs/testing/javascript-reference.md
+++ b/docs/testing/javascript-reference.md
@@ -1,4 +1,4 @@
-# Javascript API Reference
+# JavaScript API Reference
 
 Here is the complete set of API reference for the testing feature in Bruno.
 
@@ -7,19 +7,19 @@ Bruno currently has 6 globals that are available in your test script environment
 
 ### `req`
 The request that was sent. <br/>
-You can refer [here](../scripting/javascript-reference.html#request) for the complete set of api's available for `req`
+You can refer [here](../scripting/javascript-reference.html#request) for the complete set of APIs available for `req`
 
 ### `res`
 The response that was received. <br/>
-You can refer [here](../scripting/javascript-reference.html#response) for the complete set of api's available for `res`
+You can refer [here](../scripting/javascript-reference.html#response) for the complete set of APIs available for `res`
 
 ### `bru`
 `bru` allows you to load inbuilt libraries as well as set and get environment variables.<br/>
-You can refer [here](../scripting/javascript-reference.html#environments) for the api for setting and getting environment variables and [here](../scripting/inbuilt-libraries.html) to learn how to load inbuilt libraries.
+You can refer [here](../scripting/javascript-reference.html#environments) for the API for setting and getting environment variables and [here](../scripting/inbuilt-libraries.html) to learn how to load inbuilt libraries.
 
 
 ### `test`
-The `test` method allows you to write assertions for your api behavior.
+The `test` method allows you to write assertions for your API behavior.
 
 **Example:**
 ```javascript
@@ -30,7 +30,7 @@ test("should be able to login", function() {
 ```
 
 ### `expect`
-Bruno internally uses chaijs library to support bdd style expectations. You can refer the [chaijs site](https://www.chaijs.com/api/bdd) for documentation for the `expect` api
+Bruno internally uses `chaijs` library to support bdd style expectations. You can refer the [chaijs site](https://www.chaijs.com/api/bdd) for documentation for the `expect` API
 
 ### `assert`
-Bruno internally uses chaijs library to support bdd style assertions. You can refer the [chaijs site](https://www.chaijs.com/api/assert) for documentation for the `assert` api
+Bruno internally uses `chaijs` library to support bdd style assertions. You can refer the [chaijs site](https://www.chaijs.com/api/assert) for documentation for the `assert` API


### PR DESCRIPTION
1. HTTP verbs / methods updated to UPPERCASE
2. API acronym updated to UPPERCASE (removed apostrophe when plural)
3. Updated GitHub product name to match the orgs naming guidelines
4. Updated JavaScript references for consistency
5. Miscellaneous grammar / punctuation updates