### PR TITLE
Add commas to the example JSON

### DIFF
--- a/docs/bru-language-samples.md
+++ b/docs/bru-language-samples.md
@@ -29,8 +29,8 @@ post {
 
 body {
   {
-    "apiKey": "secret"
-    "numbers": "9988776655"
+    "apiKey": "secret",
+    "numbers": "9988776655",
     "message": "Woof! lets play with some apis"
   }
 }
@@ -49,7 +49,7 @@ post {
 
 body {
   {
-    "username": "johnnash"
+    "username": "johnnash",
     "password": "governingdynamics"
   }
 }
@@ -67,7 +67,7 @@ post {
 
 body {
   {
-    "username": "johnnash"
+    "username": "johnnash",
     "password": "governingdynamics"
   }
 }


### PR DESCRIPTION
Noticed this when i copied some of the example code into my editor.

Just a quick fix:)