### PR TITLE
feat: add website description

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitepress';
 // https://vitepress.vuejs.org/config/app-configs
 export default defineConfig({
   title: 'Bruno',
+  description: 'An Opensource IDE for exploring and testing APIs',
   head: [
     ['link', { rel: 'icon', href: `/bruno.svg` }]
   ],


### PR DESCRIPTION
Hi, when I posted the link to the docs to my friend I got this description

![image](https://github.com/usebruno/bruno-docs/assets/66218248/ffd69b6e-d2bd-43db-a675-b262be8d00af)

So I'd like to change this to more bruno-related information.