### PR TITLE
Documentation for whitelisting modules

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -75,6 +75,7 @@ function sidebar() {
         { text: 'External Libraries', link: '/scripting/external-libraries' },
         { text: 'Sync Requests', link: '/scripting/sync-requests' },
         { text: 'JavaScript Reference', link: '/scripting/javascript-reference' },
+        { text: 'Whitelisting Modules', link: '/scripting/whitelisting-modules' },
       ]
     },
     {

--- a/docs/scripting/whitelisting-modules.md
+++ b/docs/scripting/whitelisting-modules.md
@@ -1,0 +1,21 @@
+# Whitelisting Modules
+
+Not all built-in modules are accessible in scripts out of the box in Bruno for security reasons. You can manually enable/whitelist these modules by modifying your `bruno.json`.
+
+**Example:**
+
+To enable the `child_process` module, you can put the following in your `bruno.json` file:
+
+```json
+{
+  "scripts": {
+    "moduleWhitelist": ["child_process"],
+    "filesystemAccess": {
+      "allow": true
+    }
+  }
+}
+```
+
+Note that `filesystemAccess` is required for `child_process` to work as expected. This may be required for other built-in modules as well
+

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -31,6 +31,7 @@
 - [External Libraries](/scripting/external-libraries)
 - [Sync Requests](/scripting/sync-requests)
 - [JavaScript Reference](/scripting/javascript-reference)
+- [Whitelisting Modules](/scripting/whitelisting-modules)
 
 ## Testing
 


### PR DESCRIPTION
I couldn't find any information on using `child_process` in Bruno scripts, so I've made some documentation for how to whitelist modules in Bruno. Massive thanks to @Its-treason for the guidance in [this issue](https://github.com/usebruno/bruno/issues/1540)!

Happy to make any tweaks in case I've got something wrong, or you would prefer it structured or worded differently!