### PR TITLE
docs: Fix typo in bru-lang-overview.md

### DIFF
--- a/docs/bru-lang-overview.md
+++ b/docs/bru-lang-overview.md
@@ -12,5 +12,4 @@ Below is a sample of a Bru file for a `GET` request with some query params
 
 You can checkout the sample repository which contains GitHub rest API collection [here](https://github.com/usebruno/github-rest-api-collection)
 
-If you are wondering why had to design a DSL instead of just using JSON/YAML, you can checkout this [github discussion](https://github.com/usebruno/bruno/discussions/360)
-
+If you are wondering why we had to design a DSL instead of just using JSON/YAML, you can checkout this [github discussion](https://github.com/usebruno/bruno/discussions/360)


### PR DESCRIPTION
- Added a missing `'we'` in `docs/bru-lang-overview.md`
```md
# Before:
If you are wondering why had to...
# After:
If you are wondering why we had to...
```