### PR TITLE
docs: Fix typo in bru-language-design.md

### DIFF
--- a/docs/bru-language-design.md
+++ b/docs/bru-language-design.md
@@ -7,7 +7,7 @@ There are three kinds of blocks
 - Array blocks
 
 ### Dictionary block
-A dictionary block contains of a set of key value pairs. <br />
+A dictionary block consists of a set of key-value pairs. <br />
 ```bash
 get {
   url: https://api.textlocal.in/send


### PR DESCRIPTION
- Fixed typos in `bru-language-design.md`
```md
# Before
A dictionary block contains of a set of key value pairs.
# After
A dictionary block consists of a set of key-value pairs.
```