### PR TITLE
Add notes about environment variable commenting

### DIFF
--- a/docs/secrets-management/dotenv-file.md
+++ b/docs/secrets-management/dotenv-file.md
@@ -2,9 +2,9 @@
 
 ## DotEnv File
 
-This approach is inspired by how usually developers manage secrets in their source code.
+This approach is inspired by commonly used practices to manage secrets in source code.
 
-In this approach, you can store all your secrets in a `.env` file at the root of your collection folder.
+In this approach all secrets are stored in a `.env` file at the root of the collection folder.
 
 Bruno will automatically load the secrets from this file and make them available to your collection via `process.env.<secret-name>`.
 
@@ -22,3 +22,13 @@ And now you can safely checkin your collection to source control without worryin
 Don't forget to add `.env` to your `.gitignore` file.
 
 You can store a `.env.sample` file in your collection folder to help other developers get started with the collection.
+
+## Comments in .env file
+
+The environment file format allows for comments using the hash character (#).  Anything after the hash character will
+be ignored by default.  This includes environment variable values.  In order to use values that contain a hash character,
+place the value in double-quotes like shown below
+
+```properties
+key_name="key_value"
+```


### PR DESCRIPTION
Added some notes about commenting in environment variables and how to have hash characters in your environment value.

Reworded the .env description.