### PR TITLE
Fix links in vars.md

### DIFF
--- a/docs/scripting/vars.md
+++ b/docs/scripting/vars.md
@@ -4,9 +4,9 @@ Vars allow you to set variables before request, and after your receive the respo
 
 In the *Pre Request Variables* section, you can write any Strings, Numbers or any valid JavaScript literal.
 
-In the *Post Response Variables* section, you can write any valid JavaScript expression. The res object is available, allowing you to declaratively parse the [response](./javascript-reference.html#response) and set variables, instead of writing scripts to do the same.
+In the *Post Response Variables* section, you can write any valid JavaScript expression. The `res` object is available, allowing you to declaratively parse the [response](./response/response-object) and set variables, instead of writing scripts to do the same.
 
-For parsing the response, you can checkout the [response query](./response-query) that allows you to easily query your response.
+For parsing the response, you can checkout the [response query](./response/response-query) that allows you to easily query your response.
 
 **Example:**
 ![bru vars](../public/images/vars.png)


### PR DESCRIPTION
On https://docs.usebruno.com/scripting/vars links to **response** and **response query** lead to HTTP 404.