### PR TITLE
Fixed 'Using Secrets' link in Secrets Management > HashiCorp Vault > Overview

### DIFF
--- a/src/pages/secrets-management/hashicorp-vault/overview.mdx
+++ b/src/pages/secrets-management/hashicorp-vault/overview.mdx
@@ -6,6 +6,6 @@ Bruno allows you to easily integrate Hashicorp Vault and access your secrets sec
 
 In this guide, we will show you how to set up HashiCorp Vault with Bruno.
 
-- [Adding a secret provider](/secrets-management/hashicorp-vault/adding-a-secret-provider)
-- [Configuring and fetching secrets](/secrets-management/hashicorp-vault/configuring-and-fetching-secrets)
-- [Using secrets in Bruno](#using-secrets-in-bruno)
+- [Adding a Secret Provider](/secrets-management/hashicorp-vault/adding-a-secret-provider)
+- [Configuring and Fetching Secrets](/secrets-management/hashicorp-vault/configuring-and-fetching-secrets)
+- [Using Secrets](/secrets-management/hashicorp-vault/using-secrets)


### PR DESCRIPTION
Fixes #76 

Before: 
<img width="1112" alt="Screenshot 2024-07-22 at 18 06 11" src="https://github.com/user-attachments/assets/c9cc704a-1b0c-4ce2-87ba-e3492cd428fa">

After: 
<img width="1142" alt="Screenshot 2024-07-22 at 18 05 46" src="https://github.com/user-attachments/assets/d88b42ea-a162-46ea-958b-4ed432b87ed7">
