### PR TITLE
Updated all CLI options, keywords, file names etc. to monospace in Bruno CLI > Overview page

### DIFF
--- a/src/pages/bru-cli/overview.mdx
+++ b/src/pages/bru-cli/overview.mdx
@@ -26,41 +26,41 @@ Or run all requests in a folder:
 bru run folder
 ```
 
-If you need to use an environment, you can specify it with the --env option:
+If you need to use an environment, you can specify it with the `--env` option:
 ```bash copy
 bru run folder --env Local
 ```
 
-Pass Environment variables to your collection using the --env-var option:
+Pass Environment variables to your collection using the `--env-var` option:
 ```bash copy
 bru run folder --env Local --env-var JWT_TOKEN=1234
 ```
 
-If you need to collect the results of your API tests, you can specify the --output option:
+If you need to collect the results of your API tests, you can specify the `--output` option:
 ```bash copy
 bru run folder --output results.json
 ```
 
-If you need to run a collection with a csv file, you can specify the --csv-file-path option:
+If you need to run a collection with a csv file, you can specify the `--csv-file-path` option:
 ```bash copy
 bru run folder --csv-file-path /path/to/csv/file.csv
 ```
 
 ## Options
-| Option                | Details                                                                       |
-|-----------------------|-------------------------------------------------------------------------------|
-| -h, --help            | 	Show help                                                                    |
-| --version             | Show version number                                                           |
-| -r                    | Indicates a recursive run (default: false)                                    |
-| --cacert [string]     | CA certificate to verify peer against                                         |
-| --env [string]        | Environment variables                                                         |
-| --env-var [string]    | Overwrite a single environment variable, multiple usages possible             |
-| -o, --output [string] | Path to write file results to                                                 |
-| -f, --format [string] | Format of the file results; available formats are "json" (default) or "junit" |
-| --insecure            | Allow insecure server connections                                             |
-| --tests-only          | Only run requests that have a test                                            |
-| --bail                | Stop execution after a failure of a request, test, or assertion               |
-| --csv-file-path       | CSV file to run the collection with                                           |
+| Option                    | Details                                                                                         |
+|---------------------------|-------------------------------------------------------------------------------------------------|
+| `-h`, `--help`            | 	Show help                                                                                     |
+| `--version`               | Show version number                                                                             |
+| `-r`                      | Indicates a recursive run (default: `false`)                                                    |
+| `--cacert [string]`       | CA certificate to verify peer against                                                           |
+| `--env [string]`          | Environment name, for example `local`                                                           |
+| `--env-var [string]`      | Overwrite a single environment variable, for example `JWT_TOKEN=1234`                           |
+| `-o [string]`,<br/>`--output [string]` | Path to write file results to, for example `results.json`                          |
+| `-f [string]`,<br/>`--format [string]` | Format of the file results, available formats are JSON (default) or JUnit          |
+| `--insecure`              | Allow insecure server connections                                                               |
+| `--tests-only`            | Only run requests that have a test                                                              |
+| `--bail`                  | Stop execution after a failure of a request, test, or assertion                                 |
+| `--csv-file-path`         | CSV file to run the collection with, for example `/path/to/csv/file.csv`                        |
 
 ## Demo
 ![bru cli](/screenshots/cli-demo.webp)


### PR DESCRIPTION
Fixed #75 

In [Bruno CLI > Overview page](https://docs.usebruno.com/bru-cli/overview): 
- Updated all CLI options, keywords, file names etc. to monospace 
- removed "multiple usages possible" because nowhere those usages are listed or even mentioned / suggested, so there is no benefit for user to wonder what they might be, it is very confusing - when someone will be able to describe what those are, this text sure can make a come back 
- added examples next to CLI options for usability - so user does not have to scroll up looking for examples and coming back to options to check them out in detail  

Before: 
![FireShot Capture 055 - Bruno CLI – Bruno Docs - docs usebruno com](https://github.com/user-attachments/assets/90a97c5f-4fd1-4065-b2d6-2677f2b4b0b8)

After: 
![FireShot Capture 056 - Bruno CLI – Bruno Docs - localhost](https://github.com/user-attachments/assets/b10cb24a-0f72-4928-8c46-f0c9ab1f5bf5)
