### PR TITLE
Fixed not working links and tuned formatting #74

### DIFF
--- a/src/pages/scripting/vars.mdx
+++ b/src/pages/scripting/vars.mdx
@@ -1,16 +1,18 @@
-# Vars
+# Vars tab
 
-Vars allow you to set variables before request, and after you receive the response.
+**Vars** tab allows you to set variables:
+ - before request and
+ - after you receive the response.
 
-Vars are scoped within the request and cannot be accessed outside of it.
+Variables are scoped within the request and cannot be accessed outside of it.
 
 > Note: Prior to v1.20.0, request vars were accessible at the collection scope, but this is no longer the case.
 
-In the *Pre Request Variables* section, you can write any Strings, Numbers or any valid JavaScript literal.
+In the **Vars** tab > **Pre Request** variables section, you can write any strings, numbers or any valid JavaScript literal.
 
-In the *Post Response Variables* section, you can write any valid JavaScript expression. The res object is available, allowing you to declaratively parse the [response](./javascript-reference.html#response) and set variables, instead of writing scripts to do the same.
+In the **Vars** tab > **Post Response** variables section, you can write any valid JavaScript expression. The `res` object is available, allowing you to declaratively parse the [response object](/scripting/response/response-object) and set variables, instead of writing scripts to do the same.
 
-For parsing the response, you can checkout the [response query](./response-object) that allows you to easily query your response.
+For parsing the response, you can checkout the [response query](/scripting/response/response-query) that allows you to easily query your response.
 
 **Example:**
 ![bru vars](/screenshots/vars.webp)


### PR DESCRIPTION
Fixed #74 

UI elements in technical writing are usually bold. That is why UI elements, like **Vars** tab, are now bolded. 

The wording on the page suggested that there was something called "vars" but from what I understand it simply meant "variables". "Vars" was the clickable tab name in UI and there didn't seem to be need to have something else named "vars", so it was changed to "**Vars** tab" / "variables" where due. Hope it looks good. 

Before: 
![FireShot Capture 057 - Vars – Bruno Docs - docs usebruno com](https://github.com/user-attachments/assets/963296bb-23df-4536-96c4-2730c795578a)
<img width="1032" alt="Screenshot 2024-07-23 at 11 58 14" src="https://github.com/user-attachments/assets/0b746c0e-b346-4b3c-bd5a-c1680c3bbce0">
<img width="1277" alt="Screenshot 2024-07-23 at 11 58 54" src="https://github.com/user-attachments/assets/d3a225a3-c580-4466-ab4b-276ce97a1352">

After: 
![FireShot Capture 058 - Vars tab – Bruno Docs - localhost](https://github.com/user-attachments/assets/f4d8ddeb-784a-4802-96d4-3c40f4a164b6)

