### PR TITLE
Fix: Broken links, typos

### DIFF
--- a/src/pages/license-management/_meta.json
+++ b/src/pages/license-management/_meta.json
@@ -1,5 +1,5 @@
 {
-  "overview": "License Management",
+  "overview": "Overview",
   "golden-edition": "Golden Edition",
   "ultimate-edition": "Ultimate Edition"
 }

--- a/src/pages/scripting/request/request-object.mdx
+++ b/src/pages/scripting/request/request-object.mdx
@@ -15,7 +15,7 @@ The `req` sub-object contains detailed information about the request.
 - `script` : An object containing script-related information for the request.
 - `signal` : A signal object used to abort the request.
 - `url` : The URL of the request.
-- `vars` : An object containing any variables associated with the request. *See [variables](/scripting/variables)*.
+- `vars` : An object containing any variables associated with the request. *See [variables](/scripting/vars)*.
 
 ## Headers
 

--- a/src/pages/scripting/response/response-object.mdx
+++ b/src/pages/scripting/response/response-object.mdx
@@ -1,11 +1,11 @@
 # Response Object
 
-The `res` object that is available inside the [vars](./vars), [assertions](/testing/assertions), [scripting](./introduction) and [testing](/testing/introduction)
+The `res` object that is available inside the [vars](./vars), [assertions](/testing/assertions), [scripting](../getting-started) and [testing](/testing/introduction)
 contexts can be used to extract values from the response body, headers and status.
 
 *Note that the `res` object is only available in the context of a request.*
 
-You can also access it with [response queries](./response-queries).
+You can also access it with [response queries](./response-query).
 
 ## Object Structure
 

--- a/src/pages/scripting/response/response-query.mdx
+++ b/src/pages/scripting/response/response-query.mdx
@@ -1,6 +1,6 @@
 # Response Query
 
-The `res` object that is available inside the [vars](./vars), [assertions](/testing/assertions), [scripting](./introduction) and [testing](/testing/introduction) contexts can be queried for data by invoking it like below.
+The `res` object that is available inside the [vars](../vars), [assertions](/testing/assertions), [scripting](../getting-started) and [testing](/testing/introduction) contexts can be queried for data by invoking it like below.
 
 Think of it as `lodash.get()` on steroids
 

--- a/src/pages/scripting/vars.mdx
+++ b/src/pages/scripting/vars.mdx
@@ -8,9 +8,9 @@ Vars are scoped within the request and cannot be accessed outside of it.
 
 In the *Pre Request Variables* section, you can write any Strings, Numbers or any valid JavaScript literal.
 
-In the *Post Response Variables* section, you can write any valid JavaScript expression. The res object is available, allowing you to declaratively parse the [response](./javascript-reference.html#response) and set variables, instead of writing scripts to do the same.
+In the *Post Response Variables* section, you can write any valid JavaScript expression. The res object is available, allowing you to declaratively parse the [response](./javascript-reference#response) and set variables, instead of writing scripts to do the same.
 
-For parsing the response, you can checkout the [response query](./response-object) that allows you to easily query your response.
+For parsing the response, you can checkout the [response query](./response/response-object) that allows you to easily query your response.
 
 **Example:**
 ![bru vars](/screenshots/vars.webp)

--- a/src/pages/secrets-management/hashicorp-vault/overview.mdx
+++ b/src/pages/secrets-management/hashicorp-vault/overview.mdx
@@ -8,4 +8,4 @@ In this guide, we will show you how to set up HashiCorp Vault with Bruno.
 
 - [Adding a secret provider](/secrets-management/hashicorp-vault/adding-a-secret-provider)
 - [Configuring and fetching secrets](/secrets-management/hashicorp-vault/configuring-and-fetching-secrets)
-- [Using secrets in Bruno](#using-secrets-in-bruno)
+- [Using secrets in Bruno](./using-secrets)

--- a/src/pages/secrets-management/hashicorp-vault/using-secrets.mdx
+++ b/src/pages/secrets-management/hashicorp-vault/using-secrets.mdx
@@ -17,7 +17,7 @@ Secrets are accessed in the same way as collection and environment variables. Th
 
 <br />
 
-Secrets need to be prefixed with `$secrets` followed by the `secret name` and then the `key name`, all seperated by periods.
+Secrets need to be prefixed with `$secrets` followed by the `secret name` and then the `key name`, all separated by periods.
 
 <br />
 


### PR DESCRIPTION
Broken links in: license management, scripting, variables. 