### PR TITLE
Fix "Edit this page" sidebar link

### DIFF
--- a/src/theme.config.tsx
+++ b/src/theme.config.tsx
@@ -28,7 +28,7 @@ const themeConfig = {
   chat: {
     link: "https://discord.com/invite/KgcZUncpjq",
   },
-  docsRepositoryBase: "https://github.com/usebruno/bruno-docs",
+  docsRepositoryBase: "https://github.com/usebruno/bruno-docs/tree/main",
   head: (
     <>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
In the right-hand side bar (under the TOC), the **"Edit this page"** link is currently broken.

For example, the "Edit this page" link on [this Bruno documentation page](https://docs.usebruno.com/scripting/response/response-query) points to `https://github.com/usebruno/bruno-docs/src/pages/scripting/response/response-query.mdx` (which is 404). 

By looking at other next.js documentation sites, I think you simply have to append `tree/main` to fix the URLs. 

For example, the "Edit this page" link on [this GraphQL documentation page](https://graphql.org/learn/best-practices/) works, and here’s the relevant configuration line:
https://github.com/graphql/graphql.github.io/blob/ae6e0ec279e4915c1f7f54fae490ef3461bc1cf5/theme.config.tsx#L212-L213