### PR TITLE
Include getExecutionMode in docs

### DIFF
--- a/src/pages/scripting/javascript-reference.mdx
+++ b/src/pages/scripting/javascript-reference.mdx
@@ -111,7 +111,7 @@ const mode = req.getExecutionMode();
 ```
 
 ### `getExecutionPlatform`
-Get the plattform the current request is ran on
+Get the plattform the request is running on
 
 Returns `app` or `cli`
 

--- a/src/pages/scripting/javascript-reference.mdx
+++ b/src/pages/scripting/javascript-reference.mdx
@@ -101,13 +101,23 @@ req.setMaxRedirects(5);
 ```
 
 ### `getExecutionMode`
-Get's the current active execution mode.
+Get the current active execution mode
 
 Returns `runner` or `standalone`
 
 **Example**
 ```javascript
 const mode = req.getExecutionMode();
+```
+
+### `getExecutionPlatform`
+Get the plattform the current request is ran on
+
+Returns `app` or `cli`
+
+**Example**
+```javascript
+const mode = req.getExecutionPlatform();
 ```
 
 

--- a/src/pages/scripting/javascript-reference.mdx
+++ b/src/pages/scripting/javascript-reference.mdx
@@ -100,6 +100,17 @@ Set the maximum number of redirects to follow
 req.setMaxRedirects(5);
 ```
 
+### `getExecutionMode`
+Get's the current active execution mode.
+
+Returns `runner` or `standalone`
+
+**Example**
+```javascript
+const mode = req.getExecutionMode();
+```
+
+
 ## Response
 This `res` variable is available inside your scripting and testing context.
 


### PR DESCRIPTION
Added docs for req.getExecutionMode()

Implemented by usebruno/bruno#3200

Includes new function `req.getExecutionPlatform()` not yet implemented. Can be merged with the new implementation of @lohxt1 