### PR TITLE
Add correct example for scripting/res-query map function 

### DIFF
--- a/src/pages/scripting/response/response-query.mdx
+++ b/src/pages/scripting/response/response-query.mdx
@@ -85,7 +85,7 @@ res('..items[?].amount', i => i.amount > 20)
 
 **Example:**
 ```javascript
-res('..items[?].amount', i => i.amount + 10)
+res('..items.amount[?]', amt => amt + 10)
 ```
 
 


### PR DESCRIPTION
Issue #122 

- Updated the example in the scripting/res-query documentation to correct the usage of the map function.
- The previous example incorrectly referenced the map syntax, which may have caused confusion for users.

```js
res('..items.amount[?]', amt => amt + 10) // correct example

```