### PR TITLE
Added note on Oauth document about default callback url  

### DIFF
--- a/src/pages/auth/oauth2/overview.mdx
+++ b/src/pages/auth/oauth2/overview.mdx
@@ -5,3 +5,5 @@ Bruno currently supports OAuth2 authentication for the following three grant typ
 - [Authorization Code](/auth/oauth2/authorization-code)
 - [Client Credentials](/auth/oauth2/client-credentials)
 - [Password Credentials](/auth/oauth2/password-credentials)
+
+> Bruno does not provide a default callback URL for OAuth2. You will need to configure your own callback URL when setting up OAuth2 authentication.


### PR DESCRIPTION
Added a note in the OAuth documentation that Bruno does not provide a default callback URL like Postman. You will need to configure your own callback URL.