### PR TITLE
Improve Document by adding support for Running a JSON File via CLI in Bruno

### DIFF
--- a/src/pages/bru-cli/overview.mdx
+++ b/src/pages/bru-cli/overview.mdx
@@ -48,11 +48,20 @@ bru run folder --env Local --env-var JWT_TOKEN=1234
 ```
 
 ## Running a Collection with a CSV File
-If you need to run a collection using data from a CSV file, specify the path to the file with the --csv-file-path option:
+If you need to run a collection using data from a CSV file, specify the path to the file with the `--csv-file-path` option:
 
 ```bash copy
 bru run folder --csv-file-path /path/to/csv/file.csv
 ```
+
+## Running a Collection with a JSON File
+To run a collection using data from a JSON file, provide the file path using the `--json-file-path` option:
+
+```bash copy
+bru run folder --json-file-path /path/to/json/file.json
+```
+> This feature requires Bruno CLI version 1.35.0 or higher.
+
 
 ## Outputting Results
 To save the results of your API tests to a file, use the --output option:


### PR DESCRIPTION
 New section has been added to the documentation, providing details on how to use JSON cli feature feature.

To run a collection with a JSON file, use the following command:


`bru run folder --json-file-path /path/to/json/file.json`