### PR TITLE
Fix link on the 'Authentication & Authorization > AWS Signature' page

### DIFF
--- a/src/pages/auth/aws-signature.mdx
+++ b/src/pages/auth/aws-signature.mdx
@@ -14,7 +14,7 @@ To use AWS Signature, do the following:
 
 2. Enter your *AccessKeyID* and *SecretKey* values. 
 
-> For extra security, integrate Bruno with your secret manager to store these values in a single location. Learn more (here) [../secrets-management/hashicorp-vault/overview].
+> For extra security, integrate Bruno with your secret manager to store these values in a single location. Learn more [here](../secrets-management/hashicorp-vault/overview).
 
 The AWS Signature parameters are as follows:
 


### PR DESCRIPTION
Link notation was the wrong way around, so rendered as below

![this is https://docs.usebruno.com/auth/aws-signature as of the 31/01/2024, broken hyperlink ](https://github.com/user-attachments/assets/c4d2f6d1-dc2f-46a2-ba2a-984ec96619e7)

so now is

![fixed link](https://github.com/user-attachments/assets/804d59c9-8c64-45bd-8092-3eecbe327934)



( **aside**: I didn't run the `buildCache` as I'm making the assumption this is something done by maintainers or a build process?)