### PR TITLE
Fix typo in soap-request.mdx

### DIFF
--- a/src/pages/send-requests/soap/soap-request.mdx
+++ b/src/pages/send-requests/soap/soap-request.mdx
@@ -1,6 +1,6 @@
 # SOAP API request
 
-Bruno enables you to make HTTP cals using Simple Object Access Protocol (SOAP), a messaging protocol used for exchanging structured information between systems over a network. SOAP defines a standard for request-response communication and is based on XML data format.
+Bruno enables you to make HTTP calls using Simple Object Access Protocol (SOAP), a messaging protocol used for exchanging structured information between systems over a network. SOAP defines a standard for request-response communication and is based on XML data format.
 
 ### Key Components of a SOAP Message
 


### PR DESCRIPTION
## What

- [x] fixes `cals` to `calls` in `soap-request.mdx`
