### PR TITLE
docs: improve CLI options table formatting with code blocks

### DIFF
--- a/src/pages/bru-cli/commandOptions.mdx
+++ b/src/pages/bru-cli/commandOptions.mdx
@@ -1,4 +1,3 @@
-
 # Command Options
 
 Bruno CLI provides a variety of command options to help you customize your API testing and execution process. These options allow you to specify environments, configure reports, handle security, and much more. Below is a comprehensive list of available options:
@@ -95,25 +94,25 @@ The client-cert-config.json file should contain the following fields:
 
 | Option                       | Details                                                                       |
 | ---------------------------- | ----------------------------------------------------------------------------- |
-| -h, --help                   | Show help                                                                     |
-| --version                    | Show version number                                                           |
-| -r                           | Indicates a recursive run (default: false)                                    |
-| --cacert [string]            | CA certificate to verify peer against                                         |
-| --env [string]               | Specify environment to run with                                               |
-| --env-var [string]           | Overwrite a single environment variable, multiple usages possible             |
-| -o, --output [string]        | Path to write file results to                                                 |
-| -f, --format [string]        | Format of the file results; available formats are "json" (default) or "junit" |
-| --reporter-json [string]     | Path to generate a JSON report                                                |
-| --reporter-junit [string]    | Path to generate a JUnit report                                               |
-| --reporter-html [string]     | Path to generate an HTML report                                               |
-| --insecure                   | Allow insecure server connections                                             |
-| --tests-only                 | Only run requests that have tests                                             |
-| --bail                       | Stop execution after a failure of a request, test, or assertion               |
-| --csv-file-path              | CSV file to run the collection with                                           |
-| --reporter--skip-all-headers | Skip all headers in the report                                                |
-| --reporter-skip-headers      | Skip specific headers in the report                                           |
-| --client-cert-config         | Client certificate configuration by passing a JSON file                       |
-| --delay [number]             | Add delay to each request                                                     |
+| `-h`, `--help`              | Show help                                                                     |
+| `--version`                 | Show version number                                                           |
+| `-r`                        | Indicates a recursive run (default: false)                                    |
+| `--cacert [string]`         | CA certificate to verify peer against                                         |
+| `--env [string]`            | Specify environment to run with                                               |
+| `--env-var [string]`        | Overwrite a single environment variable, multiple usages possible             |
+| `-o`, `--output [string]`   | Path to write file results to                                                 |
+| `-f`, `--format [string]`   | Format of the file results; available formats are "json" (default) or "junit" |
+| `--reporter-json [string]`  | Path to generate a JSON report                                                |
+| `--reporter-junit [string]` | Path to generate a JUnit report                                               |
+| `--reporter-html [string]`  | Path to generate an HTML report                                               |
+| `--insecure`                | Allow insecure server connections                                             |
+| `--tests-only`              | Only run requests that have tests                                             |
+| `--bail`                    | Stop execution after a failure of a request, test, or assertion               |
+| `--csv-file-path`           | CSV file to run the collection with                                           |
+| `--reporter--skip-all-headers` | Skip all headers in the report                                            |
+| `--reporter-skip-headers`   | Skip specific headers in the report                                           |
+| `--client-cert-config`      | Client certificate configuration by passing a JSON file                       |
+| `--delay [number]`          | Add delay to each request                                                     |
 
 ## Demo
 ![bru cli](/screenshots/cli-demo.webp)


### PR DESCRIPTION
adding code blocks to stop merging of double hyphen