### PR TITLE
fix: combine regex for markdown cleanup

### DIFF
--- a/src/pages/get-started/bruno-basics/create-a-collection.mdx
+++ b/src/pages/get-started/bruno-basics/create-a-collection.mdx
@@ -4,8 +4,6 @@
 
 Create a collection by selecting `Create Collection` from the **home screen** or **top left corner** of the app.
 
-In Bruno, a **collection** is a group of **API requests** or **test scenarios** that you can organize and manage.
-
 ![create collection dialog](/screenshots/get-started/bruno-basics/create-collection/bruno_collection-1.webp)
 
 A popup dialog will appear, asking you to name your collection and choose its location in the file system. You can also choose to edit the generated folder's name.

--- a/src/pages/get-started/bruno-basics/create-a-collection.mdx
+++ b/src/pages/get-started/bruno-basics/create-a-collection.mdx
@@ -4,6 +4,8 @@
 
 Create a collection by selecting `Create Collection` from the **home screen** or **top left corner** of the app.
 
+In Bruno, a **collection** is a group of **API requests** or **test scenarios** that you can organize and manage.
+
 ![create collection dialog](/screenshots/get-started/bruno-basics/create-collection/bruno_collection-1.webp)
 
 A popup dialog will appear, asking you to name your collection and choose its location in the file system. You can also choose to edit the generated folder's name.

--- a/utils/cache/buildFileCache.ts
+++ b/utils/cache/buildFileCache.ts
@@ -6,13 +6,19 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function extractTextFromMarkdown(markdownContent: string): string {
-  const headingRegex = /^#+\s+(.*)/gm; // Matches Markdown headings
-  const htmlTagRegex = /<[^>]*>/gm; // Matches HTML tags
-  const urlRegex = /(https?:\/\/\S+)/gm; // Matches URLs starting with "http://" or "https://"
-  let plainText = markdownContent.replace(headingRegex, "$1\n");
-  plainText = plainText.replace(htmlTagRegex, "");
-  plainText = plainText.replace(urlRegex, "");
-  return plainText;
+  // Combined regex to match headings, HTML tags, and URLs
+  const regex = /^(#+\s+(.*))|(<[^>]*>)|(https?:\/\/\S+)/gm;
+  return markdownContent.replace(regex, (match, heading, htmlTag, url) => {
+    if (heading) {
+      // Replace headings with just the text after removing the '#'
+      return heading.replace(/^#+\s+/, "") + "\n";
+    }
+    if (htmlTag || url) {
+      // Remove HTML tags and URLs
+      return "";
+    }
+    return match; // Default case, return the match unchanged
+  });
 }
 
 interface FileData {


### PR DESCRIPTION
Combined the heading, HTML tag, and URL matching into a single regex, cc : @ganesh-bruno.