### PR TITLE
added deprecated tag to output and format tags

### DIFF
--- a/src/pages/bru-cli/commandOptions.mdx
+++ b/src/pages/bru-cli/commandOptions.mdx
@@ -94,8 +94,8 @@ The client-cert-config.json file should contain the following fields:
 | `--cacert [string]`         | CA certificate to verify peer against                                         |
 | `--env [string]`            | Specify environment to run with                                               |
 | `--env-var [string]`        | Overwrite a single environment variable, multiple usages possible             |
-| `-o`, `--output [string]`   | Path to write file results to                                                 |
-| `-f`, `--format [string]`   | Format of the file results; available formats are "json" (default) or "junit" |
+| `-o`, `--output [string]`   | **[DEPRECATED]** Path to write file results to. Use reporter options instead  |
+| `-f`, `--format [string]`   | **[DEPRECATED]** Format of the file results. Use reporter options instead     |
 | `--reporter-json [string]`  | Path to generate a JSON report                                                |
 | `--reporter-junit [string]` | Path to generate a JUnit report                                               |
 | `--reporter-html [string]`  | Path to generate an HTML report                                               |

--- a/src/pages/testing/automate-test/data-driven-testing.mdx
+++ b/src/pages/testing/automate-test/data-driven-testing.mdx
@@ -106,12 +106,6 @@ When you run the request, you'll see the output of these variables in the consol
 bru run --reporter-html results.html --csv-file-path /path/to/csv/file.csv
 ```
 
-or
-
-```bash copy
-bru run --output results.html --format html --csv-file-path /path/to/csv/file.csv
-```
-
 <Video src="/assets/demo-csv-runner-cli.mp4" />
 
 It will create a `results.html` file in your Bruno collection's root directory. You can view this file in your browser.


### PR DESCRIPTION
This PR includes the following changes:
- Added **Deprecated** tag to the `output` and `format` options.