### PR TITLE
added docs for openapi import on cli

### DIFF
--- a/src/pages/bru-cli/commandOptions.mdx
+++ b/src/pages/bru-cli/commandOptions.mdx
@@ -94,6 +94,24 @@ The client-cert-config.json file should contain the following fields:
 }
 ```
 
+## Importing OpenAPI Specifications
+
+Bruno CLI allows you to import OpenAPI specifications directly from the command line, which can be integrated into CI/CD pipelines whenever API changes are committed.
+
+```bash copy
+bru import openapi --source ./api-spec/petstore-v3.yaml --output ./collections/petstore --collection-name "Petstore API"
+```
+
+This will import the OpenAPI specification and generate a Bruno collection in the specified output directory.
+
+For JSON output format:
+
+```bash copy
+bru import openapi --source ./api-spec/petstore-v3.yaml --output-file ./collections/petstore-api.json --collection-name "Petstore API"
+```
+
+If no `output path` is specified, the collection will be imported to a default directory.
+
 ## Options
 
 | Option                       | Details                                                                       |
@@ -117,6 +135,10 @@ The client-cert-config.json file should contain the following fields:
 | `--reporter-skip-headers`   | Skip specific headers in the report                                           |
 | `--client-cert-config`      | Client certificate configuration by passing a JSON file                       |
 | `--delay [number]`          | Add delay to each request                                                     |
+| `--source [string]`        | Path to the OpenAPI specification file (YAML or JSON)      |
+| `--output [string]`        | Output directory to create Bruno collections as `.bru` files |
+| `--output-file [string]`   | Output file to export as Bruno collection in JSON format   |
+| `--collection-name [string]` | Name for the imported collection from OpenAPI            |
 
 ## Demo
 ![bru cli](/screenshots/cli-demo.webp)

--- a/src/pages/bru-cli/commandOptions.mdx
+++ b/src/pages/bru-cli/commandOptions.mdx
@@ -96,21 +96,31 @@ The client-cert-config.json file should contain the following fields:
 
 ## Importing OpenAPI Specifications
 
-Bruno CLI allows you to import OpenAPI specifications directly from the command line, which can be integrated into CI/CD pipelines whenever API changes are committed.
+Bruno CLI allows you to import OpenAPI specifications directly into Bruno collection from the command line, which can be integrated into CI/CD pipelines whenever API changes are committed.
+
+### Option 1: Import to Bruno Collection
+
+This will import the OpenAPI specification (supports both YAML and JSON formats) and generate a Bruno collection in the specified output directory.
 
 ```bash copy
-bru import openapi --source ./api-spec/petstore-v3.yaml --output ./collections/petstore --collection-name "Petstore API"
+bru import openapi --source <your-openapi.yaml> --output <preferred-location> --collection-name "Petstore API"
 ```
 
-This will import the OpenAPI specification and generate a Bruno collection in the specified output directory.
+Where:
+- `<your-openapi.yaml>`: Path to your OpenAPI specification file (can be either YAML or JSON format)
+- `<preferred-location>`: Directory where you want to save the collection
 
-For JSON output format:
+### Option 2: Import to Single JSON File
+
+This will import the OpenAPI specification and generate a Bruno collection as a single JSON file at the specified location.
 
 ```bash copy
-bru import openapi --source ./api-spec/petstore-v3.yaml --output-file ./collections/petstore-api.json --collection-name "Petstore API"
+bru import openapi --source <your-openapi.yaml> --output-file <preferred-location>.json --collection-name "Petstore API"
 ```
 
-If no `output path` is specified, the collection will be imported to a default directory.
+Where:
+- `<your-openapi.yaml>`: Path to your OpenAPI specification file (can be either YAML or JSON format)
+- `<preferred-location>`: Base path and filename for your JSON output
 
 ## Options
 
@@ -136,7 +146,6 @@ If no `output path` is specified, the collection will be imported to a default d
 | `--client-cert-config`      | Client certificate configuration by passing a JSON file                       |
 | `--delay [number]`          | Add delay to each request                                                     |
 | `--source [string]`        | Path to the OpenAPI specification file (YAML or JSON)      |
-| `--output [string]`        | Output directory to create Bruno collections as `.bru` files |
 | `--output-file [string]`   | Output file to export as Bruno collection in JSON format   |
 | `--collection-name [string]` | Name for the imported collection from OpenAPI            |
 


### PR DESCRIPTION
This PR addresses the following changes:
- Add docs for openapi import tag on cli - `bru import openapi`
- Added examples for both collection with `--output` and file (YAML or JSON) `--output-file`