### PR TITLE
fix typos in documentation 

### DIFF
--- a/src/pages/auth/add-and-manage-certs.mdx
+++ b/src/pages/auth/add-and-manage-certs.mdx
@@ -1,4 +1,4 @@
-# Adding and managing certifications 
+# Adding and managing certificates
 
 Bruno supports adding custom Client Authorization (CA) and client certificates to your requests if required by the API you are working with. 
 

--- a/src/pages/license-management/license-administrators/license-portal.mdx
+++ b/src/pages/license-management/license-administrators/license-portal.mdx
@@ -39,7 +39,7 @@ If you've been designated as a License Administrator, either through purchasing 
 
 > Ultimate licenses come with the ability to add users via a CSV upload
 
-- Click elipsis next to `Add User`
+- Click ellipsis next to `Add User`
 - Select `Import Users`
 - *optionally download the sample CSV to view the format for user upload*
 - Click `Upload`and select your file
@@ -57,7 +57,7 @@ If you've been designated as a License Administrator, either through purchasing 
 - Select `Delete`
 
 ### Remove Users in bulk
-- Click elipsis next to `Add User`
+- Click ellipsis next to `Add User`
 - Select `Delete Users`
 - *optionally download the sample CSV to view the format for user deletion*
 - Click `Upload`and select your file
@@ -67,7 +67,7 @@ If you've been designated as a License Administrator, either through purchasing 
 
 ## Adding License Administrators
 
-The number of Licenses Administrators you can have associated with your account is based on your [plan type](https://www.usebruno.com/pricing). 
+The number of License Administrators you can have associated with your account is based on your [plan type](https://www.usebruno.com/pricing). 
 
 - Navigate to `Settings`
 - Click on `Admins` page

--- a/src/pages/secrets-management/overview.mdx
+++ b/src/pages/secrets-management/overview.mdx
@@ -18,4 +18,4 @@ Bruno offers three (3) approaches to manage secrets in collections.
 
 - [Secret Variables](/secrets-management/secret-variables)
 - [DotEnv File](/secrets-management/dotenv-file)
-- [Inegration with a Secret Manager](/secrets-management/secret-managers)
+- [Integration with a Secret Manager](/secrets-management/secret-managers)


### PR DESCRIPTION
Change 'certifications' to 'certificates' in add-and-manage-certs.mdx - Fix 'elipsis' to 'ellipsis' in license-portal.mdx - Fix 'Licenses Administrators' to 'License Administrators' in license-portal.mdx