### PR TITLE
updated  for sendRequest

### DIFF
--- a/src/pages/bru-cli/commandOptions.mdx
+++ b/src/pages/bru-cli/commandOptions.mdx
@@ -20,10 +20,23 @@ Navigate to the directory where your API collection resides, and run the followi
 bru run
 ```
 
-This will run all the requests in your collection. If you want to run a single request, specify its filename:
+This will run all the requests in your collection. You can also run specific files or folders:
 
 ```bash copy
+# Run a single file
 bru run request.bru
+
+# Run multiple files
+bru run request1.bru request2.bru
+
+# Run a folder
+bru run folder
+
+# Run multiple folders
+bru run folder1 folder2
+
+# Mix of files and folders
+bru run folder1 request1.bru folder2 request2.bru
 ```
 
 ## Running Requests in a Folder

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra/components";
+
 # What is Bruno? 
 
 Bruno is a Git-friendly and offline-first open-source API client aimed at revolutionizing the status quo represented by tools like Postman and Insomnia. 
@@ -12,7 +14,9 @@ Bruno's superpower is collaboration through a live connection to your version co
 
 With Bruno, collections are stored directly in a folder on the filesystem. A plain text markup language, Bru, is used to save information about API requests. 
 
-> *Go to documentation for [Collaboration via Git](/git-integration/overview)*
+<Callout type="important">
+  Go to documentation for [Collaboration via Git <strong><sup>↗</sup></strong>](/git-integration/overview)
+</Callout>
 
 ### **Data Privacy and Security**
 
@@ -20,8 +24,10 @@ Legacy API clients have moved towards capturing every piece of data they can, fr
 
 Bruno is an offline tool. There's no concept of a login or account, and there is no cloud connection or syncing of the work you do in Bruno. 
 
-> - *If you or your organization purchases a Golden Edition license, your email is required simply for the issuance of a license key.* 
+<Callout type="info">
+  If you or your organization purchases a Golden Edition license, your email is required simply for the issuance of a license key.
+</Callout>
 
-> - *If your organization purchases an Ultimate Edition license, your email can be held in a self-hosted licensing server which you manage.*
-
-
+<Callout type="info">
+  If your organization purchases an Ultimate Edition license, your email can be held in a self-hosted licensing server which you manage.
+</Callout>

--- a/src/pages/testing/script/javascript-reference.mdx
+++ b/src/pages/testing/script/javascript-reference.mdx
@@ -282,7 +282,7 @@ bru.sendRequest({
   method: string,
   url: string,
   headers?: object,
-  body?: string | object,
+  data?: string | object,
   timeout?: number
 }, callback)
 ```
@@ -291,7 +291,7 @@ bru.sendRequest({
 - `method`: HTTP method (GET, POST, PUT, etc.)
 - `url`: The URL to send the request to
 - `headers`: (Optional) Request headers
-- `body`: (Optional) Request body. Can be a string or object
+- `data`: (Optional) Request data. Can be a string or object
 - `timeout`: (Optional) Request timeout in milliseconds
 - `callback`: Function to handle the response with signature `(err, res)`
 
@@ -303,7 +303,7 @@ bru.sendRequest({
   headers: {
     'Content-Type': 'application/json',
   },
-  body: JSON.stringify({ key: 'value' }),
+  data: { key: 'value' },
 }, function (err, res) {
   if (err) {
     console.error('Error:', err);
@@ -515,7 +515,6 @@ This works only in a post-request script or test-script.
 ```javascript
 bru.setNextRequest("Get process status");
 ```
-
 You can also abort the run by explicitly setting the next request to `null`
 **Example:**
 
@@ -594,3 +593,4 @@ Obtain the assertion results of a request by calling `bru.getAssertionResults` w
 ```javascript
 const assertionResults = await bru.getAssertionResults();
 ```
+


### PR DESCRIPTION
This PR addresses the following changes:
- Updated docs for the `sendRequest` method according to the axios schema: (use data instead of body.)
- Added docs in bruCLI for running multiple folders and requests (bru run folder req1.bru)
- Change the intro page similar to the `what-is-bruno` for consistent behaviour