### PR TITLE
Updated docs for Secret Manager section

### DIFF
--- a/src/pages/secrets-management/secret-managers/aws-secrets-manager/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/aws-secrets-manager/using-secrets.mdx
@@ -22,7 +22,7 @@ Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
 </Callout>
 
 <Callout type="info">
-  The secret name is the "Name" field you set when configuring the AWS Secrets Manager provider in Bruno. The key name is the specific secret key within that AWS secret.
+  If you have a secret named dbCredentials with a key username, you can reference it as: `$secrets.dbCredentials.username`
 </Callout>
 
 ## Using Secrets in Scripts

--- a/src/pages/secrets-management/secret-managers/aws-secrets-manager/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/aws-secrets-manager/using-secrets.mdx
@@ -1,4 +1,5 @@
 import PremiumBadge from "@/components/premium-badge";
+import { Callout } from 'nextra/components'
 
 # Using secrets<PremiumBadge />
 
@@ -10,14 +11,33 @@ import PremiumBadge from "@/components/premium-badge";
   Your browser does not support the video tag.
 </video>
 
-Secrets can be accessed in headers, query, body, auth input fields similar to collection and environment variables.
+## Using Secrets in Request Fields
 
+Secrets are accessed in the same way as collection and environment variables. The secrets can be accessed in headers, query, body, auth input fields similar to collection and environment variables.
 
-Secrets need to be prefixed with `$secrets` followed by the `name` and then the `key name`, all separated by periods.
+Secrets need to be prefixed with `$secrets` followed by the `secret name` and then the `key name`, all separated by periods.
 
-Pattern: `$secrets`.`<name>`.`<key-name>`.
+<Callout type="important">
+Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
+</Callout>
 
-Example:
-If you have a secret named `dbCredentials` with a key `username`, you can reference it as:
-`$secrets.dbCredentials.username`
+<Callout type="info">
+  The secret name is the "Name" field you set when configuring the AWS Secrets Manager provider in Bruno. The key name is the specific secret key within that AWS secret.
+</Callout>
+
+## Using Secrets in Scripts
+
+You can also access secrets from within Pre-request and Post-request scripts using the `bru.getSecretVar()` function.
+
+```javascript
+const secretValue = bru.getSecretVar('<secret-name>.<key-name>');
+console.log(secretValue); // This will log the value of your secret
+
+// Example: Using AWS Secrets Manager secrets in authentication
+const apiKey = bru.getSecretVar('aws-secrets.api-key');
+req.setHeader('Authorization', 'Bearer ' + apiKey);
+
+```
+
+This approach keeps your sensitive data secure while allowing you to leverage AWS Secrets Manager secrets in your API automation scripts.
 

--- a/src/pages/secrets-management/secret-managers/azure-key-vault/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/azure-key-vault/using-secrets.mdx
@@ -22,7 +22,7 @@ Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
 </Callout>
 
 <Callout type="info">
-  The secret name corresponds to the name you configured when setting up the Azure Key Vault secret provider in Bruno.
+  If you have a secret named dbCredentials with a key username, you can reference it as: `$secrets.dbCredentials.username`
 </Callout>
 
 ## Using Secrets in Scripts

--- a/src/pages/secrets-management/secret-managers/azure-key-vault/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/azure-key-vault/using-secrets.mdx
@@ -1,4 +1,5 @@
 import PremiumBadge from "@/components/premium-badge";
+import { Callout } from 'nextra/components'
 
 # Using secrets<PremiumBadge />
 
@@ -10,16 +11,33 @@ import PremiumBadge from "@/components/premium-badge";
   Your browser does not support the video tag.
 </video>
 
+## Using Secrets in Request Fields
 
-Secrets can be accessed in headers, query, body, auth input fields similar to collection and environment variables.
+Secrets are accessed in the same way as collection and environment variables. The secrets can be accessed in headers, query, body, auth input fields similar to collection and environment variables.
+
+Secrets need to be prefixed with `$secrets` followed by the `secret name` and then the `key name`, all separated by periods.
+
+<Callout type="important">
+Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
+</Callout>
+
+<Callout type="info">
+  The secret name corresponds to the name you configured when setting up the Azure Key Vault secret provider in Bruno.
+</Callout>
+
+## Using Secrets in Scripts
+
+You can also access secrets from within Pre-request and Post-request scripts using the `bru.getSecretVar()` function.
+
+```javascript
+const secretValue = bru.getSecretVar('<secret-name>.<key-name>');
+console.log(secretValue); // This will log the value of your secret
+
+// Example: Using Azure Key Vault secrets in authentication
+const apiKey = bru.getSecretVar('azure-secrets.api-key');
+req.setHeader('Authorization', 'Bearer ' + apiKey);
+```
 
 
-Secrets need to be prefixed with `$secrets` followed by the `name` and then the `key name`, all separated by periods.
-
-
-Pattern: `$secrets`.`<name>`.`<key-name>`.
-
-Example:
-If you have a secret named `dbCredentials` with a key `username`, you can reference it as:
-`$secrets.dbCredentials.username`
+Make sure your Azure Key Vault secret provider is properly configured and the secrets are fetched before using them in scripts. Verify that the secret names and key names match exactly with your Azure Key Vault configuration.
 

--- a/src/pages/secrets-management/secret-managers/hashicorp-vault/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/hashicorp-vault/using-secrets.mdx
@@ -16,7 +16,7 @@ Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
 </Callout>
 
 <Callout type="info">
-The secret name is the “Name” field you set when configuring the AWS Secrets Manager provider in Bruno. The key name is the specific secret key within that AWS secret.
+If you have a secret named dbCredentials with a key username, you can reference it as: `$secrets.dbCredentials.username`
 </Callout>
 
 ## Using Secrets in Scripts

--- a/src/pages/secrets-management/secret-managers/hashicorp-vault/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/hashicorp-vault/using-secrets.mdx
@@ -11,7 +11,13 @@ Secrets are accessed in the same way as collection and environment variables. Th
 
 Secrets need to be prefixed with `$secrets` followed by the `secret name` and then the `key name`, all separated by periods.
 
+<Callout type="important">
 Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
+</Callout>
+
+<Callout type="info">
+The secret name is the “Name” field you set when configuring the AWS Secrets Manager provider in Bruno. The key name is the specific secret key within that AWS secret.
+</Callout>
 
 ## Using Secrets in Scripts
 


### PR DESCRIPTION
This PR addresses the following changes:
- Added code example for `aws` and `azure` key vault on "How to Use Secrets in Scripts"
- Added callout for pattern syntax: `$secrets.<secret-name>.<key-name>.`
- Better description for accessing `key-name` and `secret-name`