### PR TITLE
Fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,16 +8,16 @@ The official [Bruno Documentation](https://docs.usebruno.com/) repository!
 > Ensure that Node.js (version 19 or higher) is installed before proceeding.
 
 1. Clone the repository.
-```
+```shell
 git clone https://github.com/usebruno/bruno-docs.git
 cd bruno-docs
 ```
 2. Install dependencies 
-```js
+```shell
 npm install
 ```
 3. Start development server
-```js
+```shell
 npm run dev
 ```
 

--- a/src/pages/testing/automate-test/automate-test.mdx
+++ b/src/pages/testing/automate-test/automate-test.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 # Running Automated Tests
 
-The [Bruno CLI](/bru-cli/overview) is a command line utliity that allows you to call tests from the terminal, or **integrate your test collections into a CI/CD pipeline**. 
+The [Bruno CLI](/bru-cli/overview) is a command line utility that allows you to call tests from the terminal, or **integrate your test collections into a CI/CD pipeline**.
 
 Continuous integration and continuous delivery (CI/CD) empower teams to ship software updates rapidly and reliably, maximizing user value without compromising quality. By integrating automated API tests into the build pipeline, you verify that every code change is validated and production-ready.
 


### PR DESCRIPTION
First commit is an optional one, it's more to shut up tooling than required in any way.

And the second is a dinky typo that has all the letters of the word so is readable enough as it is, but can be removed too.