### PR TITLE
Added docs for req `onFail` api

### DIFF
--- a/src/pages/testing/script/javascript-reference.mdx
+++ b/src/pages/testing/script/javascript-reference.mdx
@@ -617,7 +617,7 @@ The `onFail` function allows you to handle request errors in a custom way. This 
 
 **Syntax:**
 ```javascript
-req.onFail((error) => {
+bru.onFail((error) => {
   // Custom error handling logic
 });
 ```
@@ -628,7 +628,7 @@ req.onFail((error) => {
 **Example:**
 ```javascript
 // Handle request failures with custom logic
-req.onFail((error) => {
+bru.onFail((error) => {
   console.error('Request failed:', error.message);
   
   // Log error details for debugging
@@ -645,6 +645,6 @@ req.onFail((error) => {
 ```
 
 <Callout type="info">
-The `onFail` function should be called before the request is made (in pre-request scripts) to ensure it's properly registered for error handling.
+The `onFail` function is only available in Developer mode and should be called in pre-request scripts.
 </Callout>
 

--- a/src/pages/testing/script/javascript-reference.mdx
+++ b/src/pages/testing/script/javascript-reference.mdx
@@ -617,7 +617,7 @@ The `onFail` function allows you to handle request errors in a custom way. This 
 
 **Syntax:**
 ```javascript
-bru.onFail((error) => {
+req.onFail((error) => {
   // Custom error handling logic
 });
 ```
@@ -628,7 +628,7 @@ bru.onFail((error) => {
 **Example:**
 ```javascript
 // Handle request failures with custom logic
-bru.onFail((error) => {
+req.onFail((error) => {
   console.error('Request failed:', error.message);
   
   // Log error details for debugging

--- a/src/pages/testing/script/javascript-reference.mdx
+++ b/src/pages/testing/script/javascript-reference.mdx
@@ -609,3 +609,42 @@ Obtain the assertion results of a request by calling `bru.getAssertionResults` w
 const assertionResults = await bru.getAssertionResults();
 ```
 
+### Error Handling
+
+#### `onFail`
+
+The `onFail` function allows you to handle request errors in a custom way. This is useful for implementing custom error handling logic, logging, or taking specific actions when a request fails.
+
+**Syntax:**
+```javascript
+bru.onFail((error) => {
+  // Custom error handling logic
+});
+```
+
+**Parameters:**
+- `error`: The error object containing details about the request failure
+
+**Example:**
+```javascript
+// Handle request failures with custom logic
+bru.onFail((error) => {
+  console.error('Request failed:', error.message);
+  
+  // Log error details for debugging
+  console.log('Error details:', {
+    status: error.status,
+    statusText: error.statusText,
+    url: error.url,
+    method: error.method
+  });
+  
+  // Set a variable to track failure
+  bru.setVar('lastError', error.message);
+});
+```
+
+<Callout type="info">
+The `onFail` function should be called before the request is made (in pre-request scripts) to ensure it's properly registered for error handling.
+</Callout>
+


### PR DESCRIPTION
This PR addresses the following changes:
- Docs for `onFail` req object api
- Creates separate section for `Error Handling` 
- Adds syntax and example 