### PR TITLE
Fix/browser tab title

### DIFF
--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -1,0 +1,35 @@
+import { useConfig } from 'nextra-theme-docs'
+
+export const Head = () => {
+  const frontmatter = useConfig()
+
+  const title = ("Bruno Docs | ").concat(frontmatter.title) ?? "Bruno Docs"
+  
+  return(
+    <>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>{title}</title>
+      <meta name="description" content="Bruno is a fast and git-friendly open source API client, helping developers test and manage APIs efficiently." />
+      <meta name="keywords" content="API client, API testing, Postman alternative, REST client, GraphQL client, SOAP client, API development, git-friendly API client" />
+      <meta name="robots" content="index, follow" />
+      
+      {/* Open Graph */}
+      <meta property="og:title" content="Bruno - The Open Source API Client" />
+      <meta property="og:description" content="Fast and git-friendly open source API client for testing and managing APIs" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://docs.usebruno.com" />
+      <meta property="og:image" content="https://docs.usebruno.com/bruno.png" />
+      <meta property="og:site_name" content="Bruno Docs" />
+      
+      {/* Twitter Card */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content="Bruno - The Open Source API Client" />
+      <meta name="twitter:description" content="Fast and git-friendly open source API client for testing and managing APIs" />
+      <meta name="twitter:image" content="https://docs.usebruno.com/bruno.png" />
+      
+      <link href="/bruno.png" rel="icon" type="image/png" sizes="32x32" />
+      <link href="/bruno.png" rel="apple-touch-icon" type="image/png" sizes="32x32" />
+      <link rel="canonical" href="https://docs.usebruno.com" />
+    </>
+  )
+}

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,40 +1,7 @@
-import { DocsThemeConfig, useConfig } from 'nextra-theme-docs'
+import { DocsThemeConfig } from 'nextra-theme-docs'
 import { Navbar } from "./src/components/navbar";
 import { useRouter } from 'next/router';
-
-const CustomHead = () => {
-  const frontmatter = useConfig()
-
-  const title = ("Bruno Docs | ").concat(frontmatter.title) ?? "Bruno Docs"
-  
-  return(
-    <>
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>{title}</title>
-      <meta name="description" content="Bruno is a fast and git-friendly open source API client, helping developers test and manage APIs efficiently." />
-      <meta name="keywords" content="API client, API testing, Postman alternative, REST client, GraphQL client, SOAP client, API development, git-friendly API client" />
-      <meta name="robots" content="index, follow" />
-      
-      {/* Open Graph */}
-      <meta property="og:title" content="Bruno - The Open Source API Client" />
-      <meta property="og:description" content="Fast and git-friendly open source API client for testing and managing APIs" />
-      <meta property="og:type" content="website" />
-      <meta property="og:url" content="https://docs.usebruno.com" />
-      <meta property="og:image" content="https://docs.usebruno.com/bruno.png" />
-      <meta property="og:site_name" content="Bruno Docs" />
-      
-      {/* Twitter Card */}
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:title" content="Bruno - The Open Source API Client" />
-      <meta name="twitter:description" content="Fast and git-friendly open source API client for testing and managing APIs" />
-      <meta name="twitter:image" content="https://docs.usebruno.com/bruno.png" />
-      
-      <link href="/bruno.png" rel="icon" type="image/png" sizes="32x32" />
-      <link href="/bruno.png" rel="apple-touch-icon" type="image/png" sizes="32x32" />
-      <link rel="canonical" href="https://docs.usebruno.com" />
-    </>
-  )
-}
+import { Head } from "./src/components/head";
 
 const config: DocsThemeConfig = {
   logo: <span>Bruno Docs</span>,
@@ -45,7 +12,7 @@ const config: DocsThemeConfig = {
     link: "https://discord.com/invite/KgcZUncpjq",
   },
   docsRepositoryBase: "https://github.com/usebruno/bruno-docs/tree/main",
-  head: CustomHead,
+  head: Head,
   navbar: {
     component: Navbar
   },

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,19 +1,16 @@
-import { DocsThemeConfig } from 'nextra-theme-docs'
+import { DocsThemeConfig, useConfig } from 'nextra-theme-docs'
 import { Navbar } from "./src/components/navbar";
-import { SidebarTitle } from "./src/components/sidebar-title";
+import { useRouter } from 'next/router';
 
-const config: DocsThemeConfig = {
-  logo: <span>Bruno Docs</span>,
-  project: {
-    link: "https://github.com/usebruno/bruno",
-  },
-  chat: {
-    link: "https://discord.com/invite/KgcZUncpjq",
-  },
-  docsRepositoryBase: "https://github.com/usebruno/bruno-docs/tree/main",
-  head: (
+const CustomHead = () => {
+  const frontmatter = useConfig()
+
+  const title = ("Bruno Docs | ").concat(frontmatter.title) ?? "Bruno Docs"
+  
+  return(
     <>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>{title}</title>
       <meta name="description" content="Bruno is a fast and git-friendly open source API client, helping developers test and manage APIs efficiently." />
       <meta name="keywords" content="API client, API testing, Postman alternative, REST client, GraphQL client, SOAP client, API development, git-friendly API client" />
       <meta name="robots" content="index, follow" />
@@ -36,7 +33,19 @@ const config: DocsThemeConfig = {
       <link href="/bruno.png" rel="apple-touch-icon" type="image/png" sizes="32x32" />
       <link rel="canonical" href="https://docs.usebruno.com" />
     </>
-  ),
+  )
+}
+
+const config: DocsThemeConfig = {
+  logo: <span>Bruno Docs</span>,
+  project: {
+    link: "https://github.com/usebruno/bruno",
+  },
+  chat: {
+    link: "https://discord.com/invite/KgcZUncpjq",
+  },
+  docsRepositoryBase: "https://github.com/usebruno/bruno-docs/tree/main",
+  head: CustomHead,
   navbar: {
     component: Navbar
   },


### PR DESCRIPTION
To fix this, a custom head component was added in theme.config.tsx, using useConfig() to dynamically inject the correct title and meta description from frontmatter.
Fixes #402