### PR TITLE
Add missing js reference functions

### DIFF
--- a/src/pages/testing/script/javascript-reference.mdx
+++ b/src/pages/testing/script/javascript-reference.mdx
@@ -36,6 +36,16 @@ Set the current request url
 req.setUrl("https://api.github.com/search/repositories?q=vue");
 ```
 
+### `getAuthMode`
+
+Get the current authentication mode
+
+**Example:**
+
+```javascript
+let authMode = req.getAuthMode();
+```
+
 ### `getMethod`
 
 Get the current request method
@@ -54,6 +64,16 @@ Set the current request method
 
 ```javascript
 req.setMethod("POST");
+```
+
+### `getName`
+
+Get the current request name
+
+**Example:**
+
+```javascript
+const name = req.getName();
 ```
 
 ### `getHeader`


### PR DESCRIPTION
I've added documentation for the getName() and getAuthMode() methods.  Fixes #410 

This change impacts the [JavaScript Reference](https://docs.usebruno.com/testing/script/javascript-reference) page of the documentation, and would add the following sections:

<img width="966" height="199" alt="Screen Shot 2025-07-24 at 17 53 23" src="https://github.com/user-attachments/assets/b29392d2-6787-4c59-846a-f8175355886e" />
<img width="966" height="202" alt="Screen Shot 2025-07-24 at 17 53 12" src="https://github.com/user-attachments/assets/fc386f03-61d8-410c-bdfd-48e90c2c1bbb" />
