### PR TITLE
remove extension line

### DIFF
--- a/src/pages/bru-lang/syntax-highlighting.mdx
+++ b/src/pages/bru-lang/syntax-highlighting.mdx
@@ -1,5 +1,3 @@
 # Syntax Highlighting Support
 
 Bruno has editor extension released for VS Code.  You can download it from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno).
-
-Extensions for IntelliJ and the JetBrains family of IDEs are under development.

--- a/src/pages/bru-lang/syntax-highlighting.mdx
+++ b/src/pages/bru-lang/syntax-highlighting.mdx
@@ -1,3 +1,3 @@
 # Syntax Highlighting Support
 
-Bruno has editor extension released for VS Code.  You can download it from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno).
+Bruno has an editor extension released for VS Code that enables syntax highlighting for `.bru` files. You can download it from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno).


### PR DESCRIPTION
This PR addresses the following changes:
- Remove the description from the [Syntax Highlighting](https://docs.usebruno.com/bru-lang/syntax-highlighting) document.
- Document for `ignore` object to ignore folder view in Bruno UI.