### PR TITLE
Update - GraphQL Docs Page - Typo/Casing

### DIFF
--- a/src/pages/send-requests/graphql/overview.mdx
+++ b/src/pages/send-requests/graphql/overview.mdx
@@ -2,7 +2,7 @@
 
 Bruno can send requests using GraphQL, an open-source query language and runtime for APIs.
 
-## Graphql request
+## GraphQL request
 
 GraphQL APIs let clients request only the data they need through a single endpoint. It’s schema-driven, allowing clients to introspect and avoid overfetching or underfetching data. Each GraphQL request has a URL (the data endpoint) and a query (defining the data to retrieve or modify).
 


### PR DESCRIPTION
Graphql wasn't consistent with GraphQL naming.

- from James!