### PR TITLE
Update using-secrets.mdx doc - specify bracket inclusion

### DIFF
--- a/src/pages/secrets-management/secret-managers/azure-key-vault/using-secrets.mdx
+++ b/src/pages/secrets-management/secret-managers/azure-key-vault/using-secrets.mdx
@@ -18,11 +18,11 @@ Secrets are accessed in the same way as collection and environment variables. Th
 Secrets need to be prefixed with `$secrets` followed by the `secret name` and then the `key name`, all separated by periods.
 
 <Callout type="important">
-Pattern: `$secrets`.`<secret-name>`.`<key-name>`.
+Pattern: `{{$secrets`.`<secret-name>`.`<key-name>}}`.
 </Callout>
 
 <Callout type="info">
-  If you have a secret named dbCredentials with a key username, you can reference it as: `$secrets.dbCredentials.username`
+  If you have a secret named dbCredentials with a key username, you can reference it as: `{{$secrets.dbCredentials.username}}`
 </Callout>
 
 ## Using Secrets in Scripts


### PR DESCRIPTION
Readers use the instructions on how to reference secrets inside scripts without the proper curly brackets `{{ }}`.

The video in the docs shows this but the text is small and easily missed. Including it in the docs or a note on the syntax would be beneficial. 