### PR TITLE
doc: minor improvement in REST overview

### DIFF
--- a/src/pages/send-requests/REST/overview.mdx
+++ b/src/pages/send-requests/REST/overview.mdx
@@ -9,7 +9,7 @@ REST APIs are stateless, meaning the server does not store any information about
 | HTTP Method          | Usage                                      |
 | -------------------- | ------------------------------------------ |
 | `GET /users`         | Retrieve a list of users.                  |
-| `POST/users`         | Create a new user.                         |
+| `POST /users`        | Create a new user.                         |
 | `PUT /users/{id}`    | Update the information of a specific user. |
 | `DELETE /users/{id}` | Delete a user.                             |
 


### PR DESCRIPTION
Adjusted spacing in the "REST overview" documentation page's table. This will make the spacing consistent with all the other row items.