### PR TITLE
added couple line changes / redirect to the older license mgmt url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -84,11 +84,21 @@ export default withNextra({
       { source: '/testing/assertions.html', destination: '/testing/tests/assertions', permanent: true },
       { source: '/testing/javascript-reference.html', destination: '/testing/script/javascript-reference', permanent: true },
 
-      // - /license
-      { source: '/license-management/license-management', destination: '/license-management/overview', permanent: true },
-      { source: '/license-management/golden-edition/individual/activate-license', destination: '/license-management/overview', permanent: true },
-      { source: '/license-management/organization/manage-licenses', destination: '/license-management/overview', permanent: true },
-      { source: '/license-management/organization/activate-license', destination: '/license-management/overview', permanent: true },
+      // - /license-management redirects (old structure to new structure)
+      { source: '/license-management/license-management', destination: '/license-overview', permanent: true },
+      { source: '/license-management/overview', destination: '/license-overview', permanent: true },
+      { source: '/license-management/golden-edition/individual/activate-license', destination: '/license-end-users/activate-license', permanent: true },
+      { source: '/license-management/organization/manage-licenses', destination: '/license-administrators/license-portal', permanent: true },
+      { source: '/license-management/organization/activate-license', destination: '/license-end-users/activate-license', permanent: true },
+
+      // License Administrators redirects
+      { source: '/license-management/license-administrators/license-portal', destination: '/license-administrators/license-portal', permanent: true },
+      { source: '/license-management/license-administrators/scim-provisioning/overview', destination: '/license-administrators/scim-provisioning/overview', permanent: true },
+      { source: '/license-management/license-administrators/scim-provisioning/configure-scim-with-okta', destination: '/license-administrators/scim-provisioning/configure-scim-with-okta', permanent: true },
+      { source: '/license-management/license-administrators/scim-provisioning/bruno-scim-api', destination: '/license-administrators/scim-provisioning/bruno-scim-api', permanent: true },
+
+      // License End Users redirects
+      { source: '/license-management/license-end-users/activate-license', destination: '/license-end-users/activate-license', permanent: true },
 
       // - /bru-cli
       { source: '/cli/overview', destination: '/bru-cli/overview', permanent: true },


### PR DESCRIPTION
## Fix: Add redirects for license management documentation URLs

### Problem
The documentation URL structure was reorganized from `/license-management/*` to separate sections (`/license-overview`, `/license-administrators/*`, `/license-end-users/*`), causing 404 errors for external links and search engine results.

### Solution
Added comprehensive 301 redirects in `next.config.js` to handle all legacy `/license-management/` URLs:

- `/license-management/license-administrators/license-portal` → `/license-administrators/license-portal`
- `/license-management/license-administrators/scim-provisioning/*` → `/license-administrators/scim-provisioning/*`
- `/license-management/license-end-users/activate-license` → `/license-end-users/activate-license`
- `/license-management/overview` → `/license-overview`
- Legacy golden edition and organization URLs → appropriate new pages

### Testing
✅ Dev server starts without errors  
✅ Old URLs redirect to correct new pages  
✅ All redirects are permanent (301) for SEO

This ensures external links (Google search results, bookmarks, etc.) continue to work.

### Redirect GIF
![docs direct localhost](https://github.com/user-attachments/assets/3b48caac-a6a8-4bc9-afd6-f671979ce277)
