### PR TITLE
Correct set header params

### DIFF
--- a/src/pages/advanced-guides/starter-guide.mdx
+++ b/src/pages/advanced-guides/starter-guide.mdx
@@ -328,7 +328,7 @@ req.setBody({
   "id": "07"
 });
 
-req.setHeaders("Content-Type: application/json");
+req.setHeaders({"Content-Type": "application/json"});
 
 req.setMethod("POST");
 ```


### PR DESCRIPTION
According to https://docs.usebruno.com/testing/script/javascript-reference#header-methods, `setHeaders` expect an object.

```javascript
req.setHeader("content-type", "application/json");
```
is also a viable alternate