### PR TITLE
docs: fix Secrets by Secrets Manager

### DIFF
--- a/src/pages/secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider.mdx
+++ b/src/pages/secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider.mdx
@@ -8,7 +8,7 @@ You have the option to integrate [HashiCorp Cloud Vault <strong><sup>↗</sup></
 
 To configure a **Vault server** secret provider, you can opt for either **Token** or **AppRole** authentication.
 
-1. Go to the application settings located at the bottom of the left sidebar and navigate to the **Secrets** section.
+1. Go to the application settings located at the bottom of the left sidebar and navigate to the **Secrets Manager** section.
 
 2. Click on the `+ Add Secret Provider` button.
 
@@ -31,7 +31,7 @@ To configure a **Vault server** secret provider, you can opt for either **Token*
 
 To set up a **Vault Cloud** secret provider, follow these steps:
 
-1. Go to the application settings located at the bottom of the left sidebar and navigate to the **Secrets** section.
+1. Go to the application settings located at the bottom of the left sidebar and navigate to the **Secrets Manager** section.
 
 2. Click on the `+ Add Secret Provider` button.
 


### PR DESCRIPTION
"Secrets" section has been renamed by "Secrets Manager"

## How to review?
* check that's the current name section

## Screenshot
<img width="145" height="408" alt="brunoSecretsRename" src="https://github.com/user-attachments/assets/7ae0b9f5-40f4-43d8-8e70-ff416b76bbd4" />

