### PR TITLE
docs: fix example as subsection of debugging variables

### DIFF
--- a/src/pages/variables/overview.mdx
+++ b/src/pages/variables/overview.mdx
@@ -102,7 +102,7 @@ The pattern follows `bru.get[Type]Var(key)` where:
 - `[Type]` is the variable type (Runtime, Request, Folder, etc.)
 - `key` is the variable name you want to access
 
-### Example: 
+#### Example: 
 
 ```javascript
 // Basic syntax: console.log(bru.get[Type]Var(key))


### PR DESCRIPTION
Reason: 🧠it makes more sense, because it's related to the debugging variables in console section🧠