### PR TITLE
Add use-case descriptions to Types section on Variables overview page

### DIFF
--- a/content/variables/overview.mdx
+++ b/content/variables/overview.mdx
@@ -8,17 +8,31 @@ Variables in the Bruno allow you to store dynamic values that can be reused acro
 
 There are 7 types of variables you can create:
 
-- [Global Environments Variables](./global-environment-variables.mdx)
-- [Environment Variables](./environment-variables.mdx)
-- [Collection Variables](./collection-variables.mdx)
-- [Folder Variables](./folder-variables.mdx)
-- [Request Variables](./request-variables.mdx)
+**For dynamic session values (tokens, extracted response data):**
 - [Runtime Variables](./runtime-variables.mdx)
+
+**For one-off values defined directly in a single request:**
+- [Request Variables](./request-variables.mdx)
+
+**For values shared across all requests in a folder:**
+- [Folder Variables](./folder-variables.mdx)
+
+**For environment-specific values (dev/staging/prod URLs):**
+- [Environment Variables](./environment-variables.mdx)
+
+**For values shared across a single collection:**
+- [Collection Variables](./collection-variables.mdx)
+
+**For values shared across all Bruno collections:**
+- [Global Environments Variables](./global-environment-variables.mdx)
+
+**For prompting user input when running requests:**
 - [Prompt Variables](./prompt-variables.mdx)
 
-Additionally, Process Environment Variables can be defined in an external environment configuration file:
+Additionally, for secrets (API keys, passwords, tokens), you can use Process Environment Variables stored in a `.env` file:
 
 - [Process Environment Variables](./process-env.mdx)
+
 
 ### Variable Precedence and Scope
 


### PR DESCRIPTION
# Add use-case descriptions to Types section on Variables overview page

## Summary

Enhances the "Types" section of the Variables overview page by adding brief use-case descriptions to each variable type, helping users quickly identify which type they need without clicking through to every page.

## Problem

The current Types section lists variable types as simple bullet points with no context about when to use each one. Users must click through several different pages to understand which variable type fits their use case. This creates friction, especially for:
- New users adding their first variable
- Users choosing between similar-sounding types (Environment vs Global Environment)
- Developers deciding between Environment Variables and Process Environment Variables for secrets

## Solution

Added concise use-case descriptions to each variable type while preserving the existing structure. Each type now includes:
- A description of when to use it
- The link to detailed documentation

## Changes

- Added use-case descriptions to all 7 core variable types
- Added use-case description and context to Process Environment Variables
- Reordered the 7 core types to match the precedence shown in the existing diagram on the page, for consistency
- Clarified that Process Environment Variables are stored in `.env` files

## Impact

- Users can identify the right variable type without leaving the overview page
- Improves first-session experience for new users
- Maintains compatibility with existing documentation structure

## Testing

Tested locally with `npm run dev` - renders correctly, all links work, formatting matches existing page style.