### PR TITLE
add env variable steps and link to relevant doc

### DIFF
--- a/content/secrets-management/dotenv-file.mdx
+++ b/content/secrets-management/dotenv-file.mdx
@@ -42,6 +42,8 @@ JWT_TOKEN=your_jwt_token_value
 API_KEY=your_api_key_value
 ```
 
+3. Add the environment variables `{{process.env.<secret-name>}}` to your environment. See [Creating an Environment Variable](/variables/environment-variables#creating-an-environment-variable).
+
 These secrets will be accessible in your Bruno collection via the `process.env` object.
 
 ![dot env vars](/screenshots/secret-variables/dot-env-vars.webp)
@@ -60,6 +62,8 @@ vars {
 ```
 
 In this example, the `JWT_TOKEN` secret from the `.env` file is referenced using `process.env.JWT_TOKEN`. This will be replaced with the actual value of `JWT_TOKEN` when the collection is executed.
+
+4. Use the secrets `{{SECRET_NAME}}` in Bruno. See [Using an Environment Variable](/variables/environment-variables#using-an-environment-variable).
 
 ## Managing Secrets
 


### PR DESCRIPTION
I was a bit confused after I read this page because I had to figure out how to add an environment variable myself and didn't know how to use it. I thought all I had to do was use `JWT_TOKEN` in Auth, but actually it's `{{JWT_TOKEN}}`.

This PR should add the missing steps and also link to relevant part of the doc for the screenshots.

Welcome to edit this. I think step 3 have too much information and it makes step 4 easy to miss but I'm not sure what to do with the info in between them.