### PR TITLE
skip req callout

### DIFF
--- a/content/bruno-basics/run-a-collection.mdx
+++ b/content/bruno-basics/run-a-collection.mdx
@@ -1,6 +1,12 @@
+import { Callout } from "nextra/components";
+
 # Run a Collection
 
 Running your Bruno Collection allows you to interact with, and test, an API. We allow you to run your Collections a few different ways:
+
+<Callout type="info">
+gRPC and WebSocket requests are automatically skipped during collection runs. The Collection Runner currently supports REST and GraphQL requests only.
+</Callout>
 
 ### Collection Runner
 

--- a/content/send-requests/grpc/overview.mdx
+++ b/content/send-requests/grpc/overview.mdx
@@ -7,6 +7,10 @@ import BrunoButton from '../../../components/BrunoButton';
     GRPC support is available from Bruno 2.10.0.
 </Callout>
 
+<Callout type="warning">
+gRPC requests are automatically skipped during collection runs. This is because data-driven testing is currently supported only for REST and GraphQL requests.
+</Callout>
+
 gRPC (Google Remote Procedure Call) is a modern, high-performance Remote Procedure Call (RPC) framework developed by Google. It's designed for efficient communication when one service needs to interact with another. Imagine your Authentication Service needs to tell your Notification Service to send an OTP. 
 
 In a high-traffic scenario, traditional request-response calls (like REST over HTTP/1.1) can be less efficient and introduce latency. gRPC solves this by faster communication, efficient data transfer and streaming capabilities. 

--- a/content/send-requests/websocket/overview.mdx
+++ b/content/send-requests/websocket/overview.mdx
@@ -6,6 +6,10 @@ import { Callout } from "nextra/components";
     WebSocket support is available from Bruno 2.13.0.
 </Callout>
 
+<Callout type="warning">
+  WebSocket requests are automatically skipped during collection runs. This is because data-driven testing is currently supported only for REST and GraphQL requests.
+</Callout>
+
 Bruno now supports WebSocket connections, enabling you to test real-time communication protocols and bidirectional data exchange. This feature allows you to establish WebSocket connections, send messages, and receive responses in real-time.
 
 ## What are WebSockets?

--- a/content/testing/automate-test/data-driven-testing.mdx
+++ b/content/testing/automate-test/data-driven-testing.mdx
@@ -5,6 +5,10 @@ import { Callout } from "nextra/components";
 
 The **Collection Runner** feature allows you to iterate over data files, making it easy to automate and manage data-driven requests. Bruno supports both CSV and JSON files for running requests, so you can efficiently run tests or process multiple data inputs.
 
+<Callout type="info">
+ Data-driven testing is currently available for **REST and GraphQL requests only**. gRPC and WebSocket requests will be automatically skipped during collection runs.
+</Callout>
+
 ## Introduction
 
 In this tutorial, we'll explore the Collection Runner feature, which enables you to run collections using custom data for each iteration.


### PR DESCRIPTION
Currently, during the collection run, we are not showing `grpc` and `web sockets` . This PR adds callouts to important sections mentioning skipping requests (gRPC and WS) during the collection run.