### PR TITLE
fix: update OpenCollection YAML documentation 

### DIFF
--- a/content/opencollection-yaml/overview.mdx
+++ b/content/opencollection-yaml/overview.mdx
@@ -57,16 +57,14 @@ OpenCollection and OpenAPI serve complementary purposes:
 Here's what a simple POST request looks like in YAML format:
 
 ```yaml
-meta:
+info:
   name: Create User
+  type: http
   seq: 1
 
 http:
-  method: post
+  method: POST
   url: https://api.example.com/users
-  headers:
-    - name: Content-Type
-      value: application/json
   body:
     type: json
     data: |-
@@ -74,25 +72,33 @@ http:
         "name": "John Doe",
         "email": "john@example.com"
       }
+  auth: inherit
 
-tests: |-
-  expect(res.status).to.equal(201);
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("should return 201", function() {
+          expect(res.status).to.equal(201);
+        });
+
+settings:
+  encodeUrl: true
 ```
 
 Compare this to the equivalent `.bru` file:
 
-```bash
+```bru
 meta {
   name: Create User
+  type: http
   seq: 1
 }
 
 post {
   url: https://api.example.com/users
-}
-
-headers {
-  Content-Type: application/json
+  body: json
+  auth: inherit
 }
 
 body:json {
@@ -103,25 +109,45 @@ body:json {
 }
 
 tests {
-  expect(res.status).to.equal(201);
+  test("should return 201", function() {
+    expect(res.status).to.equal(201);
+  });
 }
 ```
 
 ## File Storage
 
-When using YAML format, your collections will be stored with `.yml` file extensions instead of `.bru`. The folder structure remains the same:
+When using YAML format, your collections will be stored with `.yml` file extensions instead of `.bru`. The folder structure uses `opencollection.yml` as the collection root file:
 
 ```
 my-collection/
-├── bruno.json           # Collection configuration
+├── opencollection.yml   # Collection configuration (YAML format)
 ├── environments/
 │   └── development.yml
 ├── users/
+│   ├── folder.yml       # Folder configuration
 │   ├── create-user.yml
 │   ├── get-user.yml
 │   └── delete-user.yml
 └── orders/
     └── create-order.yml
+```
+
+Compare this to the `.bru` format structure which uses `bruno.json`:
+
+```
+my-collection/
+├── bruno.json           # Collection configuration (Bru format)
+├── collection.bru       # Collection-level settings
+├── environments/
+│   └── development.bru
+├── users/
+│   ├── folder.bru       # Folder configuration
+│   ├── create-user.bru
+│   ├── get-user.bru
+│   └── delete-user.bru
+└── orders/
+    └── create-order.bru
 ```
 
 ## Migration

--- a/content/opencollection-yaml/samples.mdx
+++ b/content/opencollection-yaml/samples.mdx
@@ -5,83 +5,103 @@ Here are sample YAML files showing common API request patterns.
 ## GET Request
 
 ```yaml
-meta:
+info:
   name: Get User
+  type: http
   seq: 1
 
 http:
-  method: get
+  method: GET
   url: https://api.github.com/users/usebruno
+
+settings:
+  encodeUrl: true
 ```
 
 ## GET with Headers
 
 ```yaml
-meta:
+info:
   name: Get with Headers
+  type: http
   seq: 2
 
 http:
-  method: get
+  method: GET
   url: https://api.example.com/data
   headers:
     - name: Content-Type
       value: application/json
     - name: Authorization
       value: Bearer topsecret
+
+settings:
+  encodeUrl: true
 ```
 
 ## GET with Query Parameters
 
 ```yaml
-meta:
+info:
   name: Search Users
+  type: http
   seq: 3
 
 http:
-  method: get
-  url: https://api.example.com/users
+  method: GET
+  url: https://api.example.com/users?filter=active&limit=10&page=1
   params:
-    query:
-      - name: filter
-        value: active
-      - name: limit
-        value: "10"
-      - name: page
-        value: "1"
-        disabled: true
+    - name: filter
+      value: active
+      type: query
+    - name: limit
+      value: "10"
+      type: query
+    - name: page
+      value: "1"
+      type: query
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
 ```
 
 ## GET with Path Parameters
 
 ```yaml
-meta:
+info:
   name: Get User by ID
+  type: http
   seq: 4
 
 http:
-  method: get
-  url: https://api.example.com/users/:userId
+  method: GET
+  url: https://api.example.com/users/:id
   params:
-    path:
-      - name: userId
-        value: "123"
-        description: The user's unique identifier
+    - name: id
+      value: ""
+      type: path
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
 ```
 
 ## POST with JSON Body
 
 ```yaml
-meta:
+info:
   name: Create User
+  type: http
   seq: 5
 
 http:
-  method: post
+  method: POST
   url: https://api.example.com/users
-  headers:
-    - name: Content-Type
-      value: application/json
   body:
     type: json
     data: |-
@@ -89,71 +109,94 @@ http:
         "name": "John Doe",
         "email": "john@example.com"
       }
+
+settings:
+  encodeUrl: true
 ```
 
 ## POST with Form Data
 
 ```yaml
-meta:
+info:
   name: Upload Form
+  type: http
   seq: 6
 
 http:
-  method: post
+  method: POST
   url: https://api.example.com/submit
   body:
-    type: formUrlEncoded
+    type: form-urlencoded
     data:
       - name: username
         value: johndoe
       - name: password
         value: secret123
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
 ```
 
 ## Request with Authentication
 
 ```yaml
-meta:
+info:
   name: Authenticated Request
+  type: http
   seq: 7
 
 http:
-  method: get
+  method: GET
   url: https://api.example.com/protected
   auth:
     type: basic
-    basic:
-      username: admin
-      password: secret
+    username: admin
+    password: secret
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
 ```
 
 ## Request with Pre-Request Script
 
 ```yaml
-meta:
+info:
   name: Request with Script
+  type: http
   seq: 8
 
 http:
-  method: post
+  method: POST
   url: https://api.example.com/data
 
-scripts:
-  pre-request: |-
-    // Set dynamic timestamp
-    const timestamp = Date.now();
-    bru.setVar("timestamp", timestamp);
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        // Set dynamic timestamp
+        const timestamp = Date.now();
+        bru.setVar("timestamp", timestamp);
+
+settings:
+  encodeUrl: true
 ```
 
 ## Request with Post-Response Script
 
 ```yaml
-meta:
+info:
   name: Login
+  type: http
   seq: 9
 
 http:
-  method: post
+  method: POST
   url: https://api.example.com/login
   body:
     type: json
@@ -163,21 +206,27 @@ http:
         "password": "governingdynamics"
       }
 
-scripts:
-  post-response: |-
-    // Save token for subsequent requests
-    bru.setVar("token", res.body.token);
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        // Save token for subsequent requests
+        bru.setVar("token", res.body.token);
+
+settings:
+  encodeUrl: true
 ```
 
 ## Request with Tests
 
 ```yaml
-meta:
+info:
   name: Login with Tests
+  type: http
   seq: 10
 
 http:
-  method: post
+  method: POST
   url: https://api.example.com/login
   body:
     type: json
@@ -187,35 +236,42 @@ http:
         "password": "governingdynamics"
       }
 
-tests: |-
-  test("should be able to login", function() {
-    expect(res.status).to.equal(201);
-  });
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("should be able to login", function() {
+          expect(res.status).to.equal(201);
+        });
 
-  test("should receive the token", function() {
-    expect(res.body.token).to.be.a('string');
-  });
+        test("should receive the token", function() {
+          expect(res.body.token).to.be.a('string');
+        });
+
+settings:
+  encodeUrl: true
 ```
 
-## Request with Variables
+## Request with Assertions
 
 ```yaml
-meta:
-  name: Request with Variables
+info:
+  name: Request with Assertions
+  type: http
   seq: 11
 
 http:
-  method: get
+  method: POST
   url: https://api.example.com/users
 
-vars:
-  pre-request:
-    - name: userId
-      value: "123"
-      description: User ID variable
-  post-response:
-    - name: token
-      value: res.body.token
-      disabled: false
-```
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.name
+      operator: isString
 
+settings:
+  encodeUrl: true
+```

--- a/content/opencollection-yaml/structure-reference.mdx
+++ b/content/opencollection-yaml/structure-reference.mdx
@@ -7,32 +7,33 @@ This page documents the structure of OpenCollection YAML files used in Bruno.
 A Bruno YAML request file contains the following top-level sections:
 
 ```yaml
-meta:        # Request metadata
+info:        # Request metadata (name, type, seq, tags)
 http:        # HTTP request configuration
-vars:        # Variables (pre-request and post-response)
-scripts:     # JavaScript scripts
-tests:       # Test assertions
+runtime:     # Scripts and assertions
+settings:    # Request settings
 docs:        # Request documentation
 ```
 
-## meta
+## info
 
 Store metadata about your request.
 
 ```yaml
-meta:
+info:
   name: Get Users
+  type: http
   seq: 1
   tags:
     - smoke
-    - sanity
+    - regression
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | The display name of the request |
+| `type` | string | The request type (`http` for HTTP requests, `folder` for folders) |
 | `seq` | number | Sequence number that determines sort position in the UI |
-| `tags` | array | Tags for filtering requests during collection runs |
+| `tags` | array | Optional tags for filtering requests during collection runs |
 
 ## http
 
@@ -40,51 +41,45 @@ The HTTP request configuration.
 
 ```yaml
 http:
-  method: post
+  method: POST
   url: https://api.example.com/users
-  params:
-    query: [...]
-    path: [...]
   headers: [...]
+  params: [...]
   body:
     type: json
     data: "..."
   auth:
-    type: basic
-    basic:
-      username: admin
-      password: secret
+    type: bearer
+    token: "{{token}}"
 ```
 
 ### http.method
 
-The HTTP method. Supported values: `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, `trace`, `connect`.
+The HTTP method. Supported values: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, `HEAD`, `TRACE`, `CONNECT` (uppercase).
 
-### http.params.query
+### http.params
 
-Query parameters as an array of objects.
-
-```yaml
-params:
-  query:
-    - name: filter
-      value: active
-      disabled: false
-    - name: limit
-      value: "10"
-```
-
-### http.params.path
-
-Path parameters for URL templates like `/users/:userId`.
+Parameters as an array of objects with a `type` field to distinguish query vs path parameters.
 
 ```yaml
 params:
-  path:
-    - name: userId
-      value: "123"
-      description: The user's unique identifier
+  - name: filter
+    value: active
+    type: query
+  - name: limit
+    value: "10"
+    type: query
+  - name: id
+    value: "123"
+    type: path
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | The parameter name |
+| `value` | string | The parameter value |
+| `type` | string | Either `query` or `path` |
+| `disabled` | boolean | Whether the parameter is disabled (optional) |
 
 ### http.headers
 
@@ -94,11 +89,16 @@ Request headers as an array of objects.
 headers:
   - name: Content-Type
     value: application/json
-    description: Content type header
-  - name: Accept
-    value: application/json
+  - name: Authorization
+    value: Bearer {{token}}
     disabled: true
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | The header name |
+| `value` | string | The header value |
+| `disabled` | boolean | Whether the header is disabled (optional) |
 
 ### http.body
 
@@ -118,70 +118,111 @@ body:
 | `json` | JSON body |
 | `text` | Plain text body |
 | `xml` | XML body |
-| `formUrlEncoded` | Form URL-encoded data |
-| `multipartForm` | Multipart form data |
+| `form-urlencoded` | Form URL-encoded data |
+| `multipart-form` | Multipart form data |
 | `graphql` | GraphQL query |
 
 ### http.auth
 
-Authentication configuration.
+Authentication configuration. Credentials are specified directly under the `auth` object. Use `inherit` to inherit authentication from the parent folder or collection.
 
 ```yaml
+# Inherit from parent
+auth: inherit
+
+# Bearer token
+auth:
+  type: bearer
+  token: "{{token}}"
+
+# Basic authentication
 auth:
   type: basic
-  basic:
-    username: admin
-    password: secret
+  username: admin
+  password: secret
+
+# API Key
+auth:
+  type: apikey
+  key: x-api-key
+  value: "{{api-key}}"
+  placement: header
 ```
 
-Supported auth types: `none`, `basic`, `bearer`, `digest`, `oauth2`, `awsv4`, `ntlm`.
+Supported auth types: `none`, `inherit`, `basic`, `bearer`, `apikey`, `digest`, `oauth2`, `awsv4`, `ntlm`.
 
-## vars
+## runtime
 
-Define variables that can be set before or after the request.
+The runtime section contains scripts and assertions that execute during the request lifecycle.
+
+### runtime.scripts
+
+JavaScript code to run at different points in the request lifecycle.
 
 ```yaml
-vars:
-  pre-request:
-    - name: userId
-      value: "123"
-      description: User ID variable
-  post-response:
-    - name: token
-      value: res.body.token
-      disabled: false
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        // Runs before the request
+        console.log('before-request');
+        req.setHeader("X-Timestamp", Date.now());
+    - type: after-response
+      code: |-
+        // Runs after the response
+        console.log('after-response');
+        bru.setVar("token", res.body.token);
+    - type: tests
+      code: |-
+        test("should return 200", function() {
+          expect(res.status).to.equal(200);
+        });
 ```
 
-## scripts
+| Script Type | Description |
+|-------------|-------------|
+| `before-request` | Runs before the request is sent |
+| `after-response` | Runs after the response is received |
+| `tests` | Test assertions using the Chai assertion library |
 
-JavaScript code to run before or after the request.
+### runtime.assertions
+
+Declarative assertions without writing JavaScript code.
 
 ```yaml
-scripts:
-  pre-request: |-
-    // Runs before the request
-    console.log('pre-request');
-    req.setHeader("X-Timestamp", Date.now());
-  post-response: |-
-    // Runs after the response
-    console.log('post-response');
-    bru.setVar("token", res.body.token);
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+    - expression: res.body.name
+      operator: isString
 ```
 
-## tests
+| Field | Type | Description |
+|-------|------|-------------|
+| `expression` | string | The value to evaluate (e.g., `res.status`, `res.body.name`) |
+| `operator` | string | The comparison operator (`eq`, `neq`, `isString`, `isNumber`, etc.) |
+| `value` | string | The expected value (for comparison operators) |
 
-Test assertions using the Chai assertion library.
+## settings
+
+Request-level settings.
 
 ```yaml
-tests: |-
-  test("should return 200", function() {
-    expect(res.status).to.equal(200);
-  });
-
-  test("should have user data", function() {
-    expect(res.body.user).to.exist;
-  });
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `encodeUrl` | boolean | Whether to URL-encode the request URL |
+| `timeout` | number | Request timeout in milliseconds (0 = no timeout) |
+| `followRedirects` | boolean | Whether to follow HTTP redirects |
+| `maxRedirects` | number | Maximum number of redirects to follow |
 
 ## docs
 
@@ -197,4 +238,3 @@ docs: |-
   - name: User's full name
   - email: User's email address
 ```
-


### PR DESCRIPTION
## Fixes
- Update info section to use correct format (info instead of meta)
- Fix HTTP methods to use uppercase (GET, POST, etc.)
- Update params to use flat array with type field (query/path)
- Fix auth structure to be flat (not nested under auth type)
- Update body types (form-urlencoded, multipart-form)
- Add runtime section with scripts and assertions
- Add settings section documentation
- Fix docs section to use simple multiline string format
- Add tags field to info section
- Add inherit and apikey auth types

## Screenshots

<img width="982" height="778" alt="image" src="https://github.com/user-attachments/assets/6bd5f61d-685c-4333-976b-9b2af4b8881e" />

<img width="958" height="593" alt="image" src="https://github.com/user-attachments/assets/56759e66-ffd6-4284-8120-dc473e827a19" />

## Validated in Bruno

<img width="1173" height="554" alt="image" src="https://github.com/user-attachments/assets/8d6b86f2-054e-4a29-afca-e24a23542c6a" />

<img width="1179" height="674" alt="image" src="https://github.com/user-attachments/assets/da0c247a-c350-4ab8-b9eb-2b95fe487669" />
