### PR TITLE
Fix command for starting OAuth callback server

### DIFF
--- a/content/auth/oauth2-2.0/system-browser.mdx
+++ b/content/auth/oauth2-2.0/system-browser.mdx
@@ -76,7 +76,7 @@ You can host your own callback server and configure that in Bruno. Bruno will us
 If you have Node.js installed, you can quickly start a local callback server using:
 
 ```bash
-npx @usebruno/oauth-callback-server
+npx @usebruno/oauth2-callback-server
 ```
 
 This command starts a local server that automatically forwards OAuth redirects to Bruno via the deep link mechanism.


### PR DESCRIPTION
Updated the command for starting the local callback server to use the correct package name.