### PR TITLE
Process Env Variables Document Update

### DIFF
--- a/content/secrets-management/dotenv-file.mdx
+++ b/content/secrets-management/dotenv-file.mdx
@@ -11,8 +11,6 @@ In **Bruno**, environment variables can be managed through `.env` files.
 
 In **Bruno**, you can store your secrets (e.g., API keys, JWT tokens) in a `.env` file located at the **root** of your collection folder. This approach is inspired by how developers typically manage secrets in their codebase.
 
-You **cannot** create the `.env` file directly inside Bruno. You need to manually create the `.env` file at the **root** of your Bruno collection folder to store your secrets. Once created, you can access those variables within your Bruno collection.
-
 ### Folder Structure Example
 
 Below is an example folder structure for your collection:

--- a/content/testing/script/external-libraries.mdx
+++ b/content/testing/script/external-libraries.mdx
@@ -3,8 +3,11 @@ import { FileTree } from "nextra/components";
 
 # External Libraries
 
-Bruno allows you to load any npm module for use in your scripting workflows.
+Bruno allows you to load any npm module/package for use in your scripting workflows.
 
+<Callout type="warning" emoji="">
+Always turn on [Developer Mode](/configure/javascript-sandbox) when using external libraries in Bruno.
+</Callout>
 ## Prerequisites
 
 Before you begin, ensure that you have the following:

--- a/content/variables/process-env.mdx
+++ b/content/variables/process-env.mdx
@@ -7,12 +7,6 @@ import { FileTree } from "nextra/components";
 
 Process environment variables are used to store sensitive information, such as API keys, passwords, and other secret values. These values are typically stored in a .env file. For more details on secret management, refer to the [secret management](/secrets-management/dotenv-file) section.
 
-<Callout type="warning">
-  You must create the `.env` file in your local project directory (e.g., using
-  VS Code) to store your process environment variables. Bruno cannot create or
-  manage the `.env` file for you.
-</Callout>
-
 ### Creating a Process Environment Variables
 
 To create process environment variables, you can add a .env file to the root of your Bruno collection. This file will store your secrets, which can then be accessed throughout the collection.
@@ -50,3 +44,7 @@ To access the values stored in the `.env` file, you can use the `process.env` gl
 You can use `process.env.<secret-name>` throughout your Bruno collection to securely manage and access your environment variables.
 
 ![image](/screenshots/variables/using-process-env-variables.webp)
+
+<Callout type="info">
+Starting from Bruno **v3.1.0**, you can create and manage `.env` files directly inside Bruno at workspace level. Check the [Secret Management - Dotenv File](/secrets-management/dotenv-file) section for more details.
+</Callout>


### PR DESCRIPTION
- Add callout to external lib document to use `Developer Mode` 
- Remove callouts from process env variables document, as Bruno now supports creating vars  at workspace level
- Add ref in process env variables section to use DotEnv document to manage `.env` variables