### PR TITLE
Make OAuth 2 for v2+ the main docs link for OAuth. 

### DIFF
--- a/content/auth/overview.mdx
+++ b/content/auth/overview.mdx
@@ -17,9 +17,9 @@ If you enter your auth details to the `Auth` tab of your requests, we will autom
 
 ### Bruno currently supports the following authentication protocols:
 
-- [OAuth 2.0](/auth/oauth2/overview)
-- [OAuth 2.0 (Experimental)](/auth/oauth2-experimental/overview)
+- [OAuth 2.0](/auth/oauth2-experimental/overview)
 - [AWS Sig v4](/auth/aws-signature)
 - [Basic Auth](/auth/basic)
 - [Bearer Auth](/auth/bearer)
 - [Digest Auth](/auth/digest)
+- [NTLM](/auth/ntlm)


### PR DESCRIPTION
Link to v1 is on the v2 page